### PR TITLE
Use the repo data client

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ We configure Origami Registry UI using environment variables. In development, co
 
   * `NODE_ENV`: The environment to run the application in. One of `production`, `development` (default), or `test` (for use in automated tests).
   * `PORT`: The port to run the application on.
+  * `REPO_DATA_API_KEY`: The [Repo Data] API key to use when authenticating with that service.
+  * `REPO_DATA_API_SECRET`: The [Repo Data] API secret to use when authenticating with that service.
 
 ### Required in Heroku
 
@@ -177,6 +179,7 @@ The Financial Times has published this software under the [MIT license][license]
 [pingdom-eu]: https://my.pingdom.com/newchecks/checks#check=TODO
 [pingdom-us]: https://my.pingdom.com/newchecks/checks#check=TODO
 [production-url]: https://origami-registry.ft.com/
+[repo-data]: https://origami-repo-data.ft.com/
 [runbook]: https://dewey.in.ft.com/view/system/origami-registry-ui
 [sentry-production]: https://sentry.io/nextftcom/TODO
 [sentry-qa]: https://sentry.io/nextftcom/TODO

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ dotenv.load();
 const options = {
 	log: console,
 	name: 'Origami Registry',
+	repoDataApiKey: process.env.REPO_DATA_API_KEY,
+	repoDataApiSecret: process.env.REPO_DATA_API_SECRET,
 	workers: process.env.WEB_CONCURRENCY || 1
 };
 

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -10,10 +10,35 @@ module.exports = app => {
 	});
 
 	// Component listing page
-	app.get('/components', neverCache, (request, response) => {
-		response.render('components', {
-			title: `Components - ${app.origami.options.name}`
-		});
+	app.get('/components', neverCache, async (request, response, next) => {
+		try {
+			response.render('components', {
+				title: `Components - ${app.origami.options.name}`,
+				components: await app.repoData.listRepos()
+			});
+		} catch (error) {
+			next(error);
+		}
+	});
+
+	// Individual component page
+	app.get('/components/:componentId', neverCache, async (request, response, next) => {
+		try {
+			const [name, version] = request.params.componentId.split('@');
+
+			let component;
+			if (version) {
+				component = await app.repoData.getVersion(name, version);
+			} else {
+				component = await app.repoData.getRepo(name);
+			}
+			response.render('component', {
+				title: `Components - ${app.origami.options.name}`,
+				component
+			});
+		} catch (error) {
+			next(error);
+		}
 	});
 
 };

--- a/lib/service.js
+++ b/lib/service.js
@@ -2,6 +2,7 @@
 
 const healthChecks = require('./health-checks');
 const origamiService = require('@financial-times/origami-service');
+const RepoDataClient = require('@financial-times/origami-repo-data-client');
 const requireAll = require('require-all');
 
 module.exports = service;
@@ -22,6 +23,11 @@ function service(options) {
 	app.use(origamiService.middleware.errorHandler());
 
 	app.health = health;
+
+	app.repoData = new RepoDataClient({
+		apiKey: options.repoDataApiKey,
+		apiSecret: options.repoDataApiSecret
+	});
 
 	return app;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,17 @@
         "winston": "2.4.0"
       }
     },
+    "@financial-times/origami-repo-data-client": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/origami-repo-data-client/-/origami-repo-data-client-1.0.3.tgz",
+      "integrity": "sha512-jUupZfD7LMdXCsjgtkWjGtaeosWTaBQHYD8kZvVKdS8mRELUylmRIb9UIJxUDu8wdssUbZ57g0C4odhHWAH0bA==",
+      "requires": {
+        "@financial-times/origami-service-makefile": "6.1.1",
+        "lodash": "4.17.4",
+        "request": "2.83.0",
+        "request-promise-native": "1.0.5"
+      }
+    },
     "@financial-times/origami-service": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@financial-times/origami-service/-/origami-service-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@financial-times/health-check": "^1.3.0",
+    "@financial-times/origami-repo-data-client": "^1.0.3",
     "@financial-times/origami-service": "^2.4.0",
     "@financial-times/origami-service-makefile": "^6.1.0",
     "dotenv": "^4.0.0",

--- a/test/unit/lib/service.test.js
+++ b/test/unit/lib/service.test.js
@@ -11,6 +11,7 @@ describe('lib/service', () => {
 	let healthChecks;
 	let service;
 	let origamiService;
+	let RepoDataClient;
 	let requireAll;
 
 	beforeEach(() => {
@@ -24,6 +25,9 @@ describe('lib/service', () => {
 
 		origamiService = require('../mock/origami-service.mock');
 		mockery.registerMock('@financial-times/origami-service', origamiService);
+
+		RepoDataClient = require('../mock/origami-repo-data-client.mock');
+		mockery.registerMock('@financial-times/origami-repo-data-client', RepoDataClient);
 
 		requireAll = require('../mock/require-all.mock');
 		mockery.registerMock('require-all', requireAll);
@@ -43,7 +47,9 @@ describe('lib/service', () => {
 		beforeEach(() => {
 			options = {
 				environment: 'test',
-				port: 1234
+				port: 1234,
+				repoDataApiKey: 'mock-repo-data-api-key',
+				repoDataApiSecret: 'mock-repo-data-api-secret'
 			};
 			routes = {
 				foo: sinon.spy(),
@@ -106,6 +112,16 @@ describe('lib/service', () => {
 			assert.calledOnce(origamiService.middleware.errorHandler);
 			assert.calledWithExactly(origamiService.middleware.errorHandler);
 			assert.calledWith(origamiService.mockApp.use, origamiService.middleware.errorHandler.firstCall.returnValue);
+		});
+
+		it('creates a Repo Data client and stores it on the application `repoData` property', () => {
+			assert.calledOnce(RepoDataClient);
+			assert.calledWithNew(RepoDataClient);
+			assert.calledWithExactly(RepoDataClient, {
+				apiKey: 'mock-repo-data-api-key',
+				apiSecret: 'mock-repo-data-api-secret'
+			});
+			assert.strictEqual(origamiService.mockApp.repoData, RepoDataClient.mockRepoDataClient);
 		});
 
 		it('returns the created application', () => {

--- a/test/unit/mock/origami-repo-data-client.mock.js
+++ b/test/unit/mock/origami-repo-data-client.mock.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const RepoDataClient = module.exports = sinon.stub();
+
+const mockRepoDataClient = module.exports.mockRepoDataClient = {
+	isMockRepoDataClient: true
+};
+
+RepoDataClient.returns(mockRepoDataClient);

--- a/views/component.html
+++ b/views/component.html
@@ -1,0 +1,34 @@
+
+<!-- Beautiful temporary example markup -->
+
+<h1>{{component.name}}</h1>
+
+<p>{{component.description}}</p>
+
+<p><a href="{{component.url}}">Repository on GitHub</a></p>
+
+<h2>Component information</h2>
+
+<dl>
+
+	<dt>Version</dt>
+	<dd>{{component.version}}</dd>
+
+	<dt>Status</dt>
+	<dd>{{component.support.status}}</dd>
+
+</dl>
+
+<h2>Support</h2>
+
+<dl>
+
+	<dt>Email</dt>
+	<dd><a href="mailto:{{component.support.email}}?subject={{component.name}}">{{component.support.email}}</a></dd>
+
+	{{#if component.support.channel}}
+		<dt>Slack</dt>
+		<dd><a href="{{component.support.channel.url}}">{{component.support.channel.name}}</a></dd>
+	{{/if}}
+
+</dl>

--- a/views/components.html
+++ b/views/components.html
@@ -1,4 +1,28 @@
 
+<!-- Beautiful temporary example markup -->
+
 <h1>Origami Registry UI</h1>
 
 <p><strong>⚠️ This is a work in progress ⚠️</strong></p>
+
+<table class="o-table o-table--row-stripes">
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>Version</th>
+			<th>Status</th>
+		</tr>
+	</thead>
+	<tbody>
+		{{#each components}}
+			<tr>
+				<td>
+					<a href="/components/{{name}}"><strong>{{name}}</strong></a><br/>
+					{{description}}
+				</td>
+				<td>{{version}}</td>
+				<td>{{support.status}}</td>
+			</tr>
+		{{/each}}
+	</tbody>
+</table>

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -30,7 +30,7 @@
 		}
 	</style>
 
-	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-grid@^4.0.0,o-header-services@^2.0.5" />
+	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-grid@^4.0.0,o-header-services@^2.0.5,o-table@^6.3.3" />
 	<link rel="stylesheet" href="/main.css" />
 	<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
 	<script>
@@ -42,7 +42,7 @@
 				var s = document.getElementsByTagName('script')[0];
 				s.parentNode.insertBefore(o, s);
 			}
-		}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-grid@^4.0.0,o-header-services@^2.0.5'));
+		}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-grid@^4.0.0,o-header-services@^2.0.5,o-table@^6.3.3'));
 	</script>
 
 </head>


### PR DESCRIPTION
This demonstrates using the repo data client to extract information from
Origami Repo Data and display it. There need to be more calls, but this
should allow somebody else to grab the data they need and make the front
end look like the real registry.