### PR TITLE
Add integration tests for main routes

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -27,28 +27,32 @@ module.exports = app => {
 		try {
 			const [componentName, componentVersion] = request.params.componentId.split('@');
 
-			// If the component version is "latest", we can remove it
-			if (componentVersion === 'latest') {
-				return response.redirect(301, `${request.basePath}components/${componentName}`);
-			}
-
 			// Get all versions of the component so we already have the listing
 			const versions = await app.repoData.listVersions(componentName);
+			let component;
+			let mustRedirect = false;
 
 			// Select the requested version of the component
-			let component;
-			if (componentVersion) {
-				component = versions.find(version => version.version === componentVersion);
-			} else {
+			if (!componentVersion || componentVersion === 'latest') {
 				component = versions[0];
+				mustRedirect = true;
+			} else {
+				component = versions.find(version => version.version === componentVersion);
 			}
+
+			// Check that we actually have a component
 			if (!component) {
 				throw httpError(404);
 			}
 
-			// Render the view
+			// Redirect if we don't have a component version
+			if (mustRedirect) {
+				return response.redirect(307, `${request.basePath}components/${component.name}@${component.version}`);
+			}
+
+			// Render the component page
 			response.render('component', {
-				title: `Components - ${app.origami.options.name}`,
+				title: `${component.name} - ${app.origami.options.name}`,
 				component,
 				versions
 			});

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,12 @@
       "resolved": "https://registry.npmjs.org/@financial-times/origami-service-makefile/-/origami-service-makefile-6.1.1.tgz",
       "integrity": "sha1-D33dluq2OXPW+9JOq/Flwdj5Fk8="
     },
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -102,6 +108,15 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
       "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
       "dev": true
+    },
+    "acorn-globals": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.3.0"
+      }
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -216,6 +231,12 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -290,6 +311,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
@@ -476,6 +503,12 @@
         "split-string": "3.1.0",
         "to-regex": "3.0.1"
       }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -806,6 +839,12 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
+    "content-type-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+      "dev": true
+    },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -876,6 +915,21 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
+    },
+    "cssom": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.2"
+      }
     },
     "cycle": {
       "version": "1.0.3",
@@ -1000,6 +1054,15 @@
         "esutils": "2.0.2"
       }
     },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -1064,6 +1127,34 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escodegen": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "dev": true,
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "eslint": {
       "version": "4.16.0",
@@ -2758,6 +2849,15 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
       "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "1.0.3"
+      }
+    },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
@@ -3182,6 +3282,40 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "jsdom": {
+      "version": "11.6.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+      "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "acorn": "5.3.0",
+        "acorn-globals": "4.1.0",
+        "array-equal": "1.0.0",
+        "browser-process-hrtime": "0.1.2",
+        "content-type-parser": "1.0.2",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "domexception": "1.0.1",
+        "escodegen": "1.9.0",
+        "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.2.0",
+        "nwmatcher": "1.4.3",
+        "parse5": "4.0.0",
+        "pn": "1.1.0",
+        "request": "2.83.0",
+        "request-promise-native": "1.0.5",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.3",
+        "w3c-hr-time": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.3",
+        "whatwg-url": "6.4.0",
+        "ws": "4.0.0",
+        "xml-name-validator": "3.0.0"
+      }
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3249,6 +3383,12 @@
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "optional": true
     },
+    "left-pad": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3273,6 +3413,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lolex": {
@@ -3751,6 +3897,12 @@
       "requires": {
         "path-key": "2.0.1"
       }
+    },
+    "nwmatcher": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+      "dev": true
     },
     "nyc": {
       "version": "11.4.1",
@@ -5535,6 +5687,12 @@
         "semver": "5.5.0"
       }
     },
+    "parse5": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
@@ -5613,6 +5771,12 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "posix-character-classes": {
@@ -5988,6 +6152,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
       "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "semver": {
@@ -6551,6 +6721,12 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
@@ -6761,6 +6937,23 @@
         "punycode": "1.4.1"
       }
     },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        }
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -6829,6 +7022,12 @@
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
+    },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
     },
     "undefsafe": {
       "version": "2.0.1",
@@ -7156,11 +7355,46 @@
         "extsprintf": "1.3.0"
       }
     },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "0.1.2"
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
     "whatwg-fetch": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
       "dev": true
+    },
+    "whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
     },
     "which": {
       "version": "1.3.0",
@@ -7236,10 +7470,27 @@
         "signal-exit": "3.0.2"
       }
     },
+    "ws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.0.0.tgz",
+      "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "ultron": "1.1.1"
+      }
+    },
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@financial-times/grafana-tools": "^1.0.0",
     "eslint": "^4.9.0",
+    "jsdom": "^11.6.2",
     "mocha": "^4.0.1",
     "mockery": "^2.1.0",
     "nodemon": "^1.12.1",

--- a/test/integration/mock/repo-data-api/data/repos.js
+++ b/test/integration/mock/repo-data-api/data/repos.js
@@ -1,0 +1,78 @@
+'use strict';
+
+// Mock repositories for integration tests
+module.exports = [
+
+	// Active Origami component
+	{
+		name: 'o-example-active',
+		version: '2.0.0',
+		support: {
+			status: 'active',
+			email: 'origami@example.com',
+			channel: {
+				name: '#example-channel',
+				url: 'mock-channel-url'
+			},
+			isOrigami: true
+		},
+
+		// mock use only
+		_versions: ['2.0.0', '1.1.1', '1.1.0', '1.0.1', '1.0.0']
+	},
+
+	// Maintained Origami component
+	{
+		name: 'o-example-maintained',
+		version: '1.5.0',
+		support: {
+			status: 'maintained',
+			email: 'origami@example.com',
+			channel: {
+				name: '#example-channel',
+				url: 'mock-channel-url'
+			},
+			isOrigami: true
+		},
+
+		// mock use only
+		_versions: ['1.5.0', '1.4.0', '1.3.0', '1.2.0', '1.1.0', '1.0.0']
+	},
+
+	// Deprecated Origami component
+	{
+		name: 'o-example-deprecated',
+		version: '1.0.0',
+		support: {
+			status: 'deprecated',
+			email: 'origami@example.com',
+			channel: {
+				name: '#example-channel',
+				url: 'mock-channel-url'
+			},
+			isOrigami: true
+		},
+
+		// mock use only
+		_versions: ['1.0.0']
+	},
+
+	// Active non-Origami component
+	{
+		name: 'n-example-active',
+		version: '1.2.3',
+		support: {
+			status: 'active',
+			email: 'not-origami@example.com',
+			channel: {
+				name: '#example-channel',
+				url: 'mock-channel-url'
+			},
+			isOrigami: false
+		},
+
+		// mock use only
+		_versions: ['1.2.3', '1.2.2', '1.2.1', '1.2.0', '1.1.0', '1.0.0']
+	}
+
+];

--- a/test/integration/mock/repo-data-api/data/versions.js
+++ b/test/integration/mock/repo-data-api/data/versions.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const repos = require('./repos');
+const defaults = require('lodash/defaults');
+
+// Mock versions for integration tests
+const versions = module.exports = {};
+
+// Automate creation of repo versions based on
+// `_versions` property
+for (const repo of repos) {
+	versions[repo.name] = repo._versions.map(version => {
+		return defaults({version}, repo);
+	});
+}

--- a/test/integration/mock/repo-data-api/mock-service.js
+++ b/test/integration/mock/repo-data-api/mock-service.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const express = require('express');
+const httpError = require('http-errors');
+const repos = require('./data/repos');
+const versions = require('./data/versions');
+
+// Create a mock repo data API for use in integration tests
+module.exports = async function mockRepoDataApi() {
+
+	// Create an Express app powered by local JSON data
+	const api = express();
+
+	// Mount some mock routes
+	api.get('/v1/repos', (request, response) => {
+		response.send(repos);
+	});
+	api.get('/v1/repos/:name', (request, response, next) => {
+		const repo = repos.find(repo => repo.name === request.params.name);
+		if (!repo) {
+			return next(httpError(404));
+		}
+		response.send(repo);
+	});
+	api.get('/v1/repos/:name/versions', (request, response, next) => {
+		if (!versions[request.params.name]) {
+			return next(httpError(404));
+		}
+		response.send(versions[request.params.name]);
+	});
+	api.use((error, request, response, next) => { // eslint-disable-line no-unused-vars
+		response.status(error.status).send({
+			status: error.status,
+			message: error.message
+		});
+	});
+
+	// Start the API and resolve with it
+	return new Promise((resolve, reject) => {
+		const server = api.listen(error => {
+			if (error) {
+				return reject(error);
+			}
+			api.server = server;
+			api.address = `http://localhost:${server.address().port}`;
+			return resolve(api);
+		});
+	});
+
+};

--- a/test/integration/routes/404.test.js
+++ b/test/integration/routes/404.test.js
@@ -19,14 +19,14 @@ describe('GET /404', () => {
 	});
 
 	describe('HTML response', () => {
-		let response;
+		let html;
 
 		beforeEach(async () => {
-			response = (await request.then()).text;
+			html = (await request.then()).text;
 		});
 
 		it('contains the error details', () => {
-			assert.match(response, /Not Found/);
+			assert.match(html, /not found/i);
 		});
 
 	});

--- a/test/integration/routes/components-(id).test.js
+++ b/test/integration/routes/components-(id).test.js
@@ -1,0 +1,160 @@
+/* global agent */
+'use strict';
+
+const assert = require('proclaim');
+const {JSDOM} = require('jsdom');
+
+describe('GET /components/:componentId', () => {
+	let request;
+
+	describe('when a component name and version is provided', () => {
+
+		beforeEach(async () => {
+			request = agent.get('/components/o-example-active@2.0.0');
+		});
+
+		it('responds with a 200 status', () => {
+			return request.expect(200);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+		// Assertions here are based on data in `../mock/repo-data-api/data`
+		describe('HTML response', () => {
+			let dom;
+
+			beforeEach(async () => {
+				dom = new JSDOM((await request.then()).text);
+			});
+
+			it('includes a heading with the component name', () => {
+				const heading = dom.window.document.querySelector('[role=main] h1');
+				assert.isNotNull(heading);
+				assert.strictEqual(heading.textContent.trim(), 'o-example-active');
+			});
+
+			it('includes the requested version number', () => {
+				const currentVersion = dom.window.document.querySelector('[data-test=current-version]');
+				assert.isNotNull(currentVersion);
+				assert.strictEqual(currentVersion.textContent.trim(), '2.0.0');
+			});
+
+			it('includes the support status', () => {
+				const supportStatus = dom.window.document.querySelector('[data-test=support-status]');
+				assert.isNotNull(supportStatus);
+				assert.strictEqual(supportStatus.textContent.trim(), 'active');
+			});
+
+		});
+
+	});
+
+	describe('when only a component name is provided', () => {
+
+		beforeEach(async () => {
+			request = agent.get('/components/o-example-active');
+		});
+
+		it('responds with a 307 status', () => {
+			return request.expect(307);
+		});
+
+		it('responds with a Location header pointing to the latest version page', () => {
+			return request.expect('Location', '/components/o-example-active@2.0.0');
+		});
+
+	});
+
+	describe('when a component name and a "latest" version identifier is provided', () => {
+
+		beforeEach(async () => {
+			request = agent.get('/components/o-example-active@latest');
+		});
+
+		it('responds with a 307 status', () => {
+			return request.expect(307);
+		});
+
+		it('responds with a Location header pointing to the latest version page', () => {
+			return request.expect('Location', '/components/o-example-active@2.0.0');
+		});
+
+	});
+
+	describe('when a component name and an empty version identifier is provided', () => {
+
+		beforeEach(async () => {
+			request = agent.get('/components/o-example-active@');
+		});
+
+		it('responds with a 307 status', () => {
+			return request.expect(307);
+		});
+
+		it('responds with a Location header pointing to the latest version page', () => {
+			return request.expect('Location', '/components/o-example-active@2.0.0');
+		});
+
+	});
+
+	describe('when the named component does not exist', () => {
+
+		beforeEach(async () => {
+			request = agent.get('/components/o-not-a-component');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+		describe('HTML response', () => {
+			let html;
+
+			beforeEach(async () => {
+				html = (await request.then()).text;
+			});
+
+			it('contains the error details', () => {
+				assert.match(html, /not found/i);
+			});
+
+		});
+
+	});
+
+	describe('when the named component version does not exist', () => {
+
+		beforeEach(async () => {
+			request = agent.get('/components/o-example-active@123.456.789');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+		describe('HTML response', () => {
+			let html;
+
+			beforeEach(async () => {
+				html = (await request.then()).text;
+			});
+
+			it('contains the error details', () => {
+				assert.match(html, /not found/i);
+			});
+
+		});
+
+	});
+
+});

--- a/test/integration/routes/components.test.js
+++ b/test/integration/routes/components.test.js
@@ -1,6 +1,9 @@
 /* global agent */
 'use strict';
 
+const assert = require('proclaim');
+const {JSDOM} = require('jsdom');
+
 describe('GET /components', () => {
 	let request;
 
@@ -14,6 +17,44 @@ describe('GET /components', () => {
 
 	it('responds with HTML', () => {
 		return request.expect('Content-Type', /text\/html/);
+	});
+
+	// Assertions here are based on data in `../mock/repo-data-api/data`
+	describe('HTML response', () => {
+		let dom;
+		let table;
+
+		beforeEach(async () => {
+			dom = new JSDOM((await request.then()).text);
+			table = dom.window.document.querySelector('[data-test=component-table]');
+		});
+
+		it('contains a table of all components', () => {
+			assert.isNotNull(table);
+
+			const tableRows = table.querySelectorAll('tbody > tr');
+			assert.lengthEquals(tableRows, 4);
+
+			let link;
+
+			link = tableRows[0].querySelector('[data-test=component-link]');
+			assert.strictEqual(link.getAttribute('href'), '/components/o-example-active@2.0.0');
+			assert.strictEqual(link.textContent.trim(), 'o-example-active');
+
+			link = tableRows[1].querySelector('[data-test=component-link]');
+			assert.strictEqual(link.getAttribute('href'), '/components/o-example-maintained@1.5.0');
+			assert.strictEqual(link.textContent.trim(), 'o-example-maintained');
+
+			link = tableRows[2].querySelector('[data-test=component-link]');
+			assert.strictEqual(link.getAttribute('href'), '/components/o-example-deprecated@1.0.0');
+			assert.strictEqual(link.textContent.trim(), 'o-example-deprecated');
+
+			link = tableRows[3].querySelector('[data-test=component-link]');
+			assert.strictEqual(link.getAttribute('href'), '/components/n-example-active@1.2.3');
+			assert.strictEqual(link.textContent.trim(), 'n-example-active');
+
+		});
+
 	});
 
 });

--- a/test/integration/routes/index.test.js
+++ b/test/integration/routes/index.test.js
@@ -12,7 +12,7 @@ describe('GET /', () => {
 		return request.expect(301);
 	});
 
-	it('responds with a Location header', () => {
+	it('responds with a Location header pointing to the components page', () => {
 		return request.expect('Location', '/components');
 	});
 

--- a/test/integration/setup.test.js
+++ b/test/integration/setup.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const mockRepoDataApi = require('./mock/repo-data-api/mock-service');
 const service = require('../..');
 const supertest = require('supertest');
 
@@ -11,6 +12,8 @@ const mockLog = {
 };
 
 before(async () => {
+	const repoDataApi = global.repoDataApi = await mockRepoDataApi();
+	process.env.REPO_DATA_API_URL = repoDataApi.address;
 	const app = global.app = service({
 		environment: 'test',
 		log: mockLog,
@@ -25,5 +28,8 @@ after(() => {
 	if (global.app) {
 		global.app.origami.server.close();
 		global.app.health.stop();
+	}
+	if (global.repoDataApi) {
+		global.repoDataApi.server.close();
 	}
 });

--- a/views/component.html
+++ b/views/component.html
@@ -12,10 +12,10 @@
 <dl>
 
 	<dt>Version</dt>
-	<dd>{{component.version}}</dd>
+	<dd data-test="current-version">{{component.version}}</dd>
 
 	<dt>Status</dt>
-	<dd>{{component.support.status}}</dd>
+	<dd data-test="support-status">{{component.support.status}}</dd>
 
 	<dt>Versions</dt>
 	<dd>

--- a/views/components.html
+++ b/views/components.html
@@ -5,7 +5,7 @@
 
 <p><strong>⚠️ This is a work in progress ⚠️</strong></p>
 
-<table class="o-table o-table--row-stripes">
+<table class="o-table o-table--row-stripes" data-test="component-table">
 	<thead>
 		<tr>
 			<th>Name</th>
@@ -17,7 +17,7 @@
 		{{#each components}}
 			<tr>
 				<td>
-					<a href="/components/{{name}}"><strong>{{name}}</strong></a><br/>
+					<a href="/components/{{name}}@{{version}}" data-test="component-link"><strong>{{name}}</strong></a><br/>
 					{{description}}
 				</td>
 				<td>{{version}}</td>

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -50,7 +50,9 @@
 
 	{{>header}}
 
-	{{{body}}}
+	<div role="main">
+		{{{body}}}
+	</div>
 
 </body>
 </html>


### PR DESCRIPTION
This is more to demonstrate how integration tests can be written for the
HTML pages in this application. I'm asserting basic things like "there's
a link to each component on the home page" and "the component page
displays the requested version number".

This relies on a light mock Repo Data service, so that it can run
offline and the tests don't rely on the live Repo Data service.