### PR TITLE
Add data for services and image sets

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -50,18 +50,38 @@ module.exports = app => {
 				return response.redirect(307, `${request.basePath}components/${component.name}@${component.version}`);
 			}
 
-			// Load demos if the component has any
-			let demos = [];
-			if (component.resources.demos) {
+			// Load optional resources
+			let demos;
+			let images;
+			let service;
+
+			// If the component is a module and it has demos, load them
+			if (component.type === 'module' && component.resources.demos) {
 				demos = await app.repoData.listDemos(component.repo, component.id);
+
+			// If the component is an image set and it has images, load them
+			} else if (component.type === 'imageset' && component.resources.images) {
+				images = await app.repoData.listImages(component.repo, component.id, {
+					sourceParam: 'origami-registry'
+				});
+
+			// If the component is a service and it has about data, load it
+			} else if (component.type === 'service' && component.resources.manifests.about) {
+				service = await app.repoData.getManifest(component.repo, component.id, 'about');
+
 			}
+
+			// Augment the component object with a major version number, for use in image sets
+			component.majorVersion = component.version;
 
 			// Render the component page
 			response.render('component', {
 				title: `${component.name} - ${app.origami.options.name}`,
 				component,
-				versions,
-				demos
+				demos,
+				images,
+				service,
+				versions
 			});
 
 		} catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,9 +47,9 @@
       }
     },
     "@financial-times/origami-repo-data-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/origami-repo-data-client/-/origami-repo-data-client-1.1.0.tgz",
-      "integrity": "sha512-omYOuhQM3OKCQzsW0zoKzFB0fl2OXna2HxdFQSWFJOwfxzmhJy7/842uBozwqvU1swhCaHDip/MnD6631z9CTw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/origami-repo-data-client/-/origami-repo-data-client-1.2.0.tgz",
+      "integrity": "sha512-4O0JIpBYqvWXpxpqhS4DRJUd/1DrgTVSoDqOwldqzqawcKYr4gQzCP7HGTSWEIMAfPXYci5tmXIPwEmaxZtzIg==",
       "requires": {
         "@financial-times/origami-service-makefile": "6.1.1",
         "lodash": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@financial-times/health-check": "^1.3.0",
-    "@financial-times/origami-repo-data-client": "^1.1.0",
+    "@financial-times/origami-repo-data-client": "^1.2.0",
     "@financial-times/origami-service": "^2.4.0",
     "@financial-times/origami-service-makefile": "^6.1.0",
     "dotenv": "^4.0.0",

--- a/views/component.html
+++ b/views/component.html
@@ -7,19 +7,9 @@
 
 <p><a href="{{component.url}}">Repository on GitHub</a></p>
 
-{{#demos}}
-	<h2>{{title}}</h2>
-	{{#if description}}
-		<p>{{description}}</p>
-	{{/if}}
-	{{#if display.live}}
-		<p><a href="{{supportingUrls.live}}" target="_blank">Open demo in a new tab</a></p>
-		<iframe src="{{supportingUrls.live}}"></iframe>
-	{{/if}}
-	{{#if display.html}}
-		<iframe src="{{supportingUrls.html}}"></iframe>
-	{{/if}}
-{{/demos}}
+{{>component-demos}}
+{{>component-images}}
+{{>component-service-details}}
 
 
 <h2>Component information</h2>

--- a/views/partials/component-demos.html
+++ b/views/partials/component-demos.html
@@ -1,0 +1,16 @@
+
+{{#if demos}}
+	{{#demos}}
+		<h2>{{title}}</h2>
+		{{#if description}}
+			<p>{{description}}</p>
+		{{/if}}
+		{{#if display.live}}
+			<p><a href="{{supportingUrls.live}}" target="_blank">Open demo in a new tab</a></p>
+			<iframe src="{{supportingUrls.live}}"></iframe>
+		{{/if}}
+		{{#if display.html}}
+			<iframe src="{{supportingUrls.html}}"></iframe>
+		{{/if}}
+	{{/demos}}
+{{/if}}

--- a/views/partials/component-images.html
+++ b/views/partials/component-images.html
@@ -1,0 +1,20 @@
+
+{{#if images}}
+
+	<h2>Image Set</h2>
+
+	<!--
+	TODO remove inline styles from here: they're just in place to make the page smaller
+	while we test things out
+	-->
+
+	<ul style="display: flex; flex-wrap: wrap; align-content: space-around; list-style: none; padding-left: 0;">
+		{{#images}}
+			<li style="width: 100px; margin-right: 10px; margin-bottom: 10px;">
+				<img src="{{supportingUrls.w200}}" alt="{{title}}" style="display: block; width: 100px"/>
+				{{title}}
+			</li>
+		{{/images}}
+	</ul>
+
+{{/if}}

--- a/views/partials/component-service-details.html
+++ b/views/partials/component-service-details.html
@@ -1,0 +1,34 @@
+
+{{#if service}}
+	<h2>Service Details</h2>
+
+	<dl>
+		{{#if service.systemCode}}
+			<dt>System code</dt>
+			<dd>{{service.systemCode}}</dd>
+		{{/if}}
+
+		{{#if service.serviceTier}}
+			<dt>Service tier</dt>
+			<dd>{{service.serviceTier}}</dd>
+		{{/if}}
+
+		{{#if service.primaryUrl}}
+			<dt>URL</dt>
+			<dd><a href="{{service.primaryUrl}}">{{service.primaryUrl}}</a></dd>
+		{{/if}}
+
+	</dl>
+
+	{{#if service.links}}
+		<h2>Service Links</h2>
+		<ul>
+			{{#service.links}}
+				<li class="service-link--{{category}}">
+					<a href="{{url}}">{{#if description}}{{description}}{{else}}{{url}}{{/if}}</a>
+				</li>
+			{{/service.links}}
+		</ul>
+	{{/if}}
+
+{{/if}}


### PR DESCRIPTION
Services and image sets now display all the information we have on them.
I've split things into partials a little more to help organise the
views. There are a few nasty things in the views at the moment, like
inline styles, but I think this is alright as we should be replacing all
the markup as part of the front end build.