### PR TITLE
Try using bash conditionals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ else
 endif
 
 check-for-bower-components:
-ifeq (,$(wildcard ./bower_components))
-	@echo "now bower_components found, installing..."
-	@npx origami-build-tools install
-else
-	@echo "bower_components found, no need to install"
-endif
+	@if [ -d bower_components ]; then \
+		echo "bower_components found, no need to install"; \
+	else \
+		echo "no bower_components found, installing..."; \
+		npx origami-build-tools install; \
+	fi
 
 clean-bower-components:
 	@rm -rf bower_components/


### PR DESCRIPTION
Make conditionals are run at the beginning of a Make process, and so
aren't affected by other Make targets, if that makes sense. So what was
happening is:

  1. Make process is started, the bower_components folder exists at this
     point so the "else" statement is the code that ends up being used
  2. The bower_components folder is deleted. Although it's no longer
     there, the conditional still falls into the "else" statement
  3. The bower components are never installed and the build fails

...I think