### PR TITLE
Match overview

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/Financial-Times/origami-registry-ui",
   "dependencies": {
     "o-header-services": "^2.0.5",
-    "o-table": "^6.3.3",
+    "o-table": "^6.5.0",
     "o-grid": "^4.3.7",
     "o-autoinit": "^1.3.3",
     "o-colors": "^4.1.5",

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const capitalise = string => string.charAt(0).toUpperCase() + string.slice(1);
+
+module.exports = { capitalise };

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -10,12 +10,37 @@ module.exports = app => {
 		maxAge: 0
 	});
 
+	const categoriseRepos = async () => {
+		const repos = await app.repoData.listRepos();
+		const categories = {
+			primitives: [],
+			components: [],
+			layouts: [],
+			utilities: [],
+			imagesets: [],
+			uncategorised: []
+		};
+
+		repos.forEach(repo => {
+			if (repo.subType === null) {
+				if (repo.type === 'imageset') {
+					categories['imagesets'].push(repo);
+				} else {
+					categories['uncategorised'].push(repo);
+				}
+			} else {
+				categories[repo.subType].push(repo);
+			}
+		});
+		return categories;
+	};
+
 	// Component listing page
 	app.get('/components', neverCache, async (request, response, next) => {
 		try {
 			response.render('components', {
 				title: `Components - ${app.origami.options.name}`,
-				components: await app.repoData.listRepos()
+				categories: await categoriseRepos()
 			});
 		} catch (error) {
 			next(error);

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -38,7 +38,7 @@ module.exports = app => {
 	// Component listing page
 	app.get('/components', neverCache, async (request, response, next) => {
 		try {
-			response.render('components', {
+			response.render('overview', {
 				title: `Components - ${app.origami.options.name}`,
 				categories: await categoriseRepos()
 			});

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -29,7 +29,11 @@ module.exports = app => {
 					categories['uncategorised'].push(repo);
 				}
 			} else {
-				categories[repo.subType].push(repo);
+				if (categories[repo.subType]) {
+					categories[repo.subType].push(repo);
+				} else {
+					categories['uncategorised'].push(repo);
+				}
 			}
 		});
 		return categories;

--- a/lib/service.js
+++ b/lib/service.js
@@ -14,6 +14,7 @@ function service(options) {
 	options.goodToGoTest = health.gtg();
 	options.about = require('../about.json');
 	options.defaultLayout = 'main';
+	options.handlebarsHelpers = require('./helpers');
 
 	const app = origamiService(options);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,10 +38,11 @@
       }
     },
     "@financial-times/n-logger": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-5.5.11.tgz",
-      "integrity": "sha1-0Ltk50HfAAjNPMXmR+m/ZoAKF80=",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-5.6.2.tgz",
+      "integrity": "sha1-3AQsFDb36NSGrr3M/CB6lUSeIgw=",
       "requires": {
+        "isomorphic-fetch": "2.2.1",
         "request": "2.83.0",
         "winston": "2.4.0"
       }
@@ -58,9 +59,9 @@
       }
     },
     "@financial-times/origami-service": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/origami-service/-/origami-service-2.4.0.tgz",
-      "integrity": "sha512-uv+adQWfPpXruyAHacJugckGD2YybdV/I3UJwPDTPSDlwtGGtJ07mF2s8WMAZXa10YTzQiyUeMJ6J/gEyDkq6w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/origami-service/-/origami-service-2.5.0.tgz",
+      "integrity": "sha512-f3Hb+Bpcg1LBBZjFAED3zQdBPeV3gDWCTVvm7fhV0l80ieIvpjy2fHIB6fi4pj+CNau3GRjFhol7WzU8Kj0msw==",
       "requires": {
         "@financial-times/express-web-service": "3.4.4",
         "express": "4.16.2",
@@ -69,7 +70,7 @@
         "lodash": "4.17.4",
         "morgan": "1.9.0",
         "ms": "2.1.1",
-        "next-metrics": "1.48.30",
+        "next-metrics": "1.48.32",
         "raven": "1.2.1",
         "request": "2.83.0",
         "request-promise-native": "1.0.5",
@@ -413,7 +414,7 @@
         "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "1.6.16"
       }
     },
     "boom": {
@@ -1112,7 +1113,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
       "requires": {
         "iconv-lite": "0.4.19"
       }
@@ -1481,7 +1481,7 @@
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "2.0.3",
         "qs": "6.5.1",
         "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
@@ -1489,7 +1489,7 @@
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
         "vary": "1.1.2"
       }
@@ -3015,9 +3015,9 @@
       }
     },
     "ipaddr.js": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
     "is": {
       "version": "3.2.1",
@@ -3219,8 +3219,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -3249,7 +3248,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
       "requires": {
         "node-fetch": "1.7.3",
         "whatwg-fetch": "2.0.3"
@@ -3752,11 +3750,11 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "next-metrics": {
-      "version": "1.48.30",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-1.48.30.tgz",
-      "integrity": "sha1-KY45rNs4ZzUNadmjNCQ1r6hRW8I=",
+      "version": "1.48.32",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-1.48.32.tgz",
+      "integrity": "sha1-PrBMCfn6l/otlMP6QsEni0Z0tCE=",
       "requires": {
-        "@financial-times/n-logger": "5.5.11",
+        "@financial-times/n-logger": "5.6.2",
         "debug": "1.0.5",
         "lodash": "2.4.2",
         "metrics": "0.1.14"
@@ -3822,7 +3820,6 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
@@ -5827,12 +5824,12 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.5.2"
+        "ipaddr.js": "1.6.0"
       }
     },
     "ps-tree": {
@@ -6984,12 +6981,27 @@
       "dev": true
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "2.1.18"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        }
       }
     },
     "typedarray": {
@@ -7382,8 +7394,7 @@
     "whatwg-fetch": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
-      "dev": true
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "whatwg-url": {
       "version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@financial-times/health-check": "^1.3.0",
     "@financial-times/origami-repo-data-client": "^1.2.0",
-    "@financial-times/origami-service": "^2.4.0",
+    "@financial-times/origami-service": "^2.5.0",
     "@financial-times/origami-service-makefile": "^6.1.0",
     "dotenv": "^4.0.0",
     "heroku-node-settings": "^1.1.0",

--- a/src/js/click-helper.js
+++ b/src/js/click-helper.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = (function() {
+	const links = document.querySelectorAll('.o-registry-ui__table-cell--link');
+	Array.from(links, link => {
+		const row = link.parentNode.parentNode;
+		if (link.href) {
+			row.addEventListener('click', () => { location.href = link.href; });
+		}
+	});
+}());

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./click-helper');
+require('./demo');

--- a/src/main.js
+++ b/src/main.js
@@ -4,4 +4,4 @@ require('o-header-services');
 require('o-table');
 require('o-autoinit');
 
-require('./js/demo');
+require('./js/main');

--- a/src/main.scss
+++ b/src/main.scss
@@ -15,6 +15,7 @@ $o-normalise-is-silent: false;
 @import 'src/scss/variables';
 @import 'src/scss/header';
 @import 'src/scss/overview';
+@import 'src/scss/sidebar';
 
 @include oFontsInclude(MetricWeb, regular);
 @include oFontsInclude(MetricWeb, semibold);

--- a/src/main.scss
+++ b/src/main.scss
@@ -12,7 +12,7 @@ $o-normalise-is-silent: false;
 @import 'o-table/main';
 
 // Includes.
-@import 'src/scss/variables';
+@import 'src/scss/colors';
 @import 'src/scss/header';
 @import 'src/scss/overview';
 @import 'src/scss/sidebar';

--- a/src/main.scss
+++ b/src/main.scss
@@ -14,14 +14,10 @@ $o-normalise-is-silent: false;
 // Includes.
 @import 'src/scss/variables';
 @import 'src/scss/header';
-@import 'src/scss/table';
+@import 'src/scss/overview';
 
 @include oFontsInclude(MetricWeb, regular);
 @include oFontsInclude(MetricWeb, semibold);
-
-.typography-wrapper {
-    @include oTypographyWrapper($style: product);
-}
 
 .container {
     @include oGridContainer($grid-mode: "fluid", $bleed: true);

--- a/src/scss/_colors.scss
+++ b/src/scss/_colors.scss
@@ -1,0 +1,5 @@
+@include oColorsSetColor('grey-10', oColorsMix(black, white, 10));
+@include oColorsSetColor('grey-20', oColorsMix(black, white, 20));
+@include oColorsSetColor('grey-30', oColorsMix(black, white, 30));
+@include oColorsSetColor('grey-60', oColorsMix(black, white, 60));
+@include oColorsSetColor('grey-80', oColorsMix(black, white, 80));

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -1,13 +1,13 @@
 .o-header-services__primary-nav {
-	background: $_o-registry-ui-base;
-	border-bottom-color: $_o-registry-ui-highlight;
+	background-color: oColorsGetPaletteColor('grey-10');
+	border-bottom-color: oColorsGetPaletteColor('grey-30');;
 	@include oTypographyMargin($bottom: 5);
 }
 
 .o-header-services__nav-link:hover,
 .o-header-services__nav-link--selected,
 .o-header-services__nav-link[aria-selected=true] {
-	background-color: $_o-registry-ui-highlight;
+	background-color: oColorsGetPaletteColor('grey-30');;
 }
 
 .wip-notice {

--- a/src/scss/_overview.scss
+++ b/src/scss/_overview.scss
@@ -1,5 +1,5 @@
 @import 'src/scss/table';
 
 .o-registry-ui__overview {
-	padding: 20px;
+	display: flex;
 }

--- a/src/scss/_overview.scss
+++ b/src/scss/_overview.scss
@@ -1,0 +1,5 @@
+@import 'src/scss/table';
+
+.o-registry-ui__overview {
+	padding: 20px;
+}

--- a/src/scss/_sidebar.scss
+++ b/src/scss/_sidebar.scss
@@ -1,0 +1,23 @@
+.o-registry-ui__sidebar {
+	@include oTypographySans(0);
+	flex-shrink: 2;
+	border-left: 1px solid $_o-registry-ui-base;
+	max-width: 35%;
+
+	@include oGridRespondTo($until: M) {
+		display: none;
+	};
+}
+
+.o-registry-ui__sidebar--content {
+	position: sticky;
+	top: 0;
+	align-self: flex-start;
+	background-color: $_o-registry-ui-base;
+	padding: 4px 20px;
+	margin: 0 24px;
+}
+
+pre {
+	overflow: scroll;
+}

--- a/src/scss/_sidebar.scss
+++ b/src/scss/_sidebar.scss
@@ -1,23 +1,30 @@
 .o-registry-ui__sidebar {
 	@include oTypographySans(0);
 	flex-shrink: 2;
-	border-left: 1px solid $_o-registry-ui-base;
+	border-left: 1px solid oColorsGetPaletteColor('grey-10');
 	max-width: 35%;
 
 	@include oGridRespondTo($until: M) {
 		display: none;
 	};
-}
 
-.o-registry-ui__sidebar--content {
-	position: sticky;
-	top: 0;
-	align-self: flex-start;
-	background-color: $_o-registry-ui-base;
-	padding: 4px 20px;
-	margin: 0 24px;
-}
+	&--content {
+		position: sticky;
+		top: 0;
+		align-self: flex-start;
+		background-color: oColorsGetPaletteColor('grey-10');
+		padding: oTypographySpacingSize(1) oTypographySpacingSize(5);
+		margin: 0 oTypographySpacingSize(6);
 
-pre {
-	overflow: scroll;
+		a {
+			@include oTypographyLink();
+		}
+
+		pre {
+			overflow: scroll;
+			tab-size: 0;
+			padding: oTypographySpacingSize(2);
+			background-color: oColorsGetPaletteColor('grey-20');;
+		}
+	}
 }

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -60,6 +60,11 @@
 	padding: 2px 6px 4px 6px;
 	text-align: center;
 	border-radius: 5px;
+	margin: 0 4px;
+
+	@include oGridRespondTo(M) {
+		margin: 0;
+	};
 
  	&--active {
 		background-color: oColorsMix('jade', 'black', 80);

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -6,6 +6,10 @@
 	tr:hover {
 		background: $_o-registry-ui-hover;
 	}
+
+	td {
+		vertical-align: middle;
+	}
 }
 
 .o-registry-ui__table-cell--link {
@@ -16,7 +20,7 @@
 
 .o-registry-ui__table-cell--description {
 	@include oTypographySans($scale: 0);
-	@include oTypographyMargin($top: 2);
+	@include oTypographyMargin($top: 2, $bottom: 1);
 	color: $_o-registry-ui-sub-text;
 	font-weight: 400;
 }
@@ -30,9 +34,32 @@
 }
 
 .o-registry-ui__table-cell--info {
+	@include oTypographyPadding($top: 2);
 	display: table-cell;
 	color: $_o-registry-ui-text;
 	@include oGridRespondTo(M) {
 		display: none;
 	};
+}
+
+.o-registry-ui__table-cell-label {
+	@include oTypographySansBold(-1);
+	padding: 2px 6px 4px 6px;
+	text-align: center;
+	border-radius: 5px;
+
+ 	&--active {
+		background-color: oColorsMix('jade', 'black', 80);
+		color: oColorsGetTextColor(oColorsMix('jade', 'black', 80), 100);
+	}
+
+ 	&--experimental {
+		background-color: oColorsGetPaletteColor('lemon');
+		color: oColorsGetTextColor(oColorsGetPaletteColor('lemon'), 100);
+	}
+
+ 	&--deprecated {
+		background-color: oColorsGetPaletteColor('crimson');
+		color: oColorsGetTextColor(oColorsGetPaletteColor('crimson'), 100);
+	}
 }

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -7,6 +7,19 @@
 		background: $_o-registry-ui-hover;
 	}
 
+	.o-registry-ui__group-title {
+		border-bottom: 1px solid $_o-registry-ui-hover;
+
+		td {
+			@include oTypographySansBold(0);
+			@include oTypographyPadding($top: 4, $bottom: 4);
+		}
+
+		&:hover {
+			background: none;
+		}
+	}
+
 	td {
 		vertical-align: middle;
 	}

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -8,7 +8,7 @@
 }
 
 .o-registry-ui__table-body {
-	tr:hover {
+	tr:not(.o-registry-ui__group-title):hover {
 		background-color: oColorsGetPaletteColor('grey-20');;
 	}
 
@@ -22,10 +22,6 @@
 		td {
 			@include oTypographySansBold(0);
 			@include oTypographyPadding($top: 4, $bottom: 4);
-		}
-
-		&:hover {
-			background-color: none;
 		}
 	}
 }

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -68,7 +68,8 @@
 		margin: 0;
 	};
 
- 	&--active {
+ 	&--active,
+	&--maintained {
 		background-color: oColorsMix('jade', 'black', 80);
 		color: oColorsGetTextColor(oColorsMix('jade', 'black', 80), 100);
 	}

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -9,7 +9,7 @@
 }
 
 .o-registry-ui__table-cell--link {
-	@include oTypographySans($scale: 1);
+	@include oTypographySansBold($scale: 1);
 	text-decoration: none;
 	color: $_o-registry-ui-text;
 }
@@ -19,4 +19,20 @@
 	@include oTypographyMargin($top: 2);
 	color: $_o-registry-ui-sub-text;
 	font-weight: 400;
+}
+
+.o-registry-ui__table-cell--show {
+	display: none;
+
+	@include oGridRespondTo(M) {
+		display: table-cell;
+	};
+}
+
+.o-registry-ui__table-cell--info {
+	display: table-cell;
+	color: $_o-registry-ui-text;
+	@include oGridRespondTo(M) {
+		display: none;
+	};
 }

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -1,3 +1,8 @@
+.o-registry-ui__components {
+	padding: 20px;
+	flex-grow: 1;
+}
+
 .o-registry-ui__table-head {
 	background: $_o-registry-ui-base;
 }

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -4,16 +4,20 @@
 }
 
 .o-registry-ui__table-head {
-	background: $_o-registry-ui-base;
+	background-color: oColorsGetPaletteColor('grey-10');
 }
 
 .o-registry-ui__table-body {
 	tr:hover {
-		background: $_o-registry-ui-hover;
+		background-color: oColorsGetPaletteColor('grey-20');;
+	}
+
+	td {
+		vertical-align: middle;
 	}
 
 	.o-registry-ui__group-title {
-		border-bottom: 1px solid $_o-registry-ui-hover;
+		border-bottom: 1px solid oColorsGetPaletteColor('grey-20');;
 
 		td {
 			@include oTypographySansBold(0);
@@ -21,42 +25,39 @@
 		}
 
 		&:hover {
-			background: none;
+			background-color: none;
+		}
+	}
+}
+
+.o-registry-ui__table-cell {
+	&--link {
+		@include oTypographySansBold($scale: 1);
+		text-decoration: none;
+		color: oColorsGetPaletteColor('grey-80');;
+	}
+
+	&--description {
+		@include oTypographySans($scale: 0);
+		@include oTypographyMargin($top: 2, $bottom: 1);
+		color: oColorsGetPaletteColor('grey-60');;
+		font-weight: 400;
+	}
+
+	&--show {
+		display: none;
+		@include oGridRespondTo(M) {
+			display: table-cell;
 		}
 	}
 
-	td {
-		vertical-align: middle;
-	}
-}
-
-.o-registry-ui__table-cell--link {
-	@include oTypographySansBold($scale: 1);
-	text-decoration: none;
-	color: $_o-registry-ui-text;
-}
-
-.o-registry-ui__table-cell--description {
-	@include oTypographySans($scale: 0);
-	@include oTypographyMargin($top: 2, $bottom: 1);
-	color: $_o-registry-ui-sub-text;
-	font-weight: 400;
-}
-
-.o-registry-ui__table-cell--show {
-	display: none;
-
-	@include oGridRespondTo(M) {
+	&--info {
+		@include oTypographyPadding($top: 2);
 		display: table-cell;
-	};
-}
-
-.o-registry-ui__table-cell--info {
-	@include oTypographyPadding($top: 2);
-	display: table-cell;
-	color: $_o-registry-ui-text;
-	@include oGridRespondTo(M) {
-		display: none;
+		color: oColorsGetPaletteColor('grey-80');;
+		@include oGridRespondTo(M) {
+			display: none;
+		}
 	};
 }
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,6 +1,0 @@
-//TODO: add new colors to palette so we can set usecases (oColorsSetUseCase only accepts o-colors palette colors), pending design input
-$_o-registry-ui-base: oColorsMix(black, white, 10);
-$_o-registry-ui-highlight: oColorsMix(black, white, 30);
-$_o-registry-ui-hover: oColorsMix(black, white, 20);
-$_o-registry-ui-text: oColorsMix(black, white, 80);
-$_o-registry-ui-sub-text: oColorsMix(black, white, 60);

--- a/test/integration/mock/repo-data-api/data/repos.js
+++ b/test/integration/mock/repo-data-api/data/repos.js
@@ -6,6 +6,8 @@ module.exports = [
 	// Active Origami component
 	{
 		name: 'o-example-active',
+		type: 'module',
+		subType: 'primitives',
 		version: '2.0.0',
 		support: {
 			status: 'active',
@@ -27,6 +29,8 @@ module.exports = [
 	// Maintained Origami component
 	{
 		name: 'o-example-maintained',
+		type: null,
+		subType: null,
 		version: '1.5.0',
 		support: {
 			status: 'maintained',
@@ -48,6 +52,8 @@ module.exports = [
 	// Deprecated Origami component
 	{
 		name: 'o-example-deprecated',
+		type: null,
+		subType: null,
 		version: '1.0.0',
 		support: {
 			status: 'deprecated',
@@ -69,6 +75,8 @@ module.exports = [
 	// Active non-Origami component
 	{
 		name: 'n-example-active',
+		type: null,
+		subType: null,
 		version: '1.2.3',
 		support: {
 			status: 'active',

--- a/test/integration/routes/components.test.js
+++ b/test/integration/routes/components.test.js
@@ -11,7 +11,7 @@ describe('GET /components', () => {
 		request = agent.get('/components');
 	});
 
-	it('responds with a 200 status', () => {
+	it('responds with a 200 status', async () => {
 		return request.expect(200);
 	});
 
@@ -32,7 +32,7 @@ describe('GET /components', () => {
 		it('contains a table of all components', () => {
 			assert.isNotNull(table);
 
-			const tableRows = table.querySelectorAll('tbody > tr');
+			const tableRows = table.querySelectorAll('[data-test=component-row]');
 			assert.lengthEquals(tableRows, 4);
 
 			let link;

--- a/test/unit/lib/helpers/index.test.js
+++ b/test/unit/lib/helpers/index.test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const assert = require('proclaim');
+// const sinon = require('sinon');
+
+const helper = require('../../../../lib/helpers');
+
+describe('helpers', () => {
+	it('capitalises a string', () => {
+		const string = 'lowercase';
+		assert.strictEqual(helper.capitalise(string), 'Lowercase');
+	});
+});

--- a/views/components.html
+++ b/views/components.html
@@ -7,15 +7,15 @@
 
 	<table class="o-table o-registry-ui__table" data-o-component='o-table' data-test="component-table">
 		<thead class="o-registry-ui__table-head">
-			<tr>
+			<tr class="o-registry-ui__table-cell--show">
 				<th>Component</th>
-				<th data-o-table-data-type="numeric" class='o-table__cell--numeric o-registry-ui__table-cell--show'>Version</th>
-				<th class="o-registry-ui__table-cell--show">Status</th>
+				<th data-o-table-data-type="numeric" class='o-table__cell--numeric'>Version</th>
+				<th>Status</th>
 			</tr>
 		</thead>
 		<tbody class="o-registry-ui__table-body">
 			{{#each components}}
-				<tr>
+				<tr style="cursor:pointer;">
 					<td>
 						<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
 						<p class='o-registry-ui__table-cell--description'>{{description}}

--- a/views/components.html
+++ b/views/components.html
@@ -8,9 +8,9 @@
 	<table class="o-table o-registry-ui__table" data-o-component='o-table' data-test="component-table">
 		<thead class="o-registry-ui__table-head">
 			<tr>
-				<th class="o-registry-ui__table-cell--show">Component</th>
-				<th data-o-table-data-type="numeric" class="o-table__cell--numeric o-registry-ui__table-cell--show">Version</th>
-				<th class="o-registry-ui__table-cell--show">Status</th>
+				<th data-o-table-heading-disable-sort class="o-registry-ui__table-cell--show">Component</th>
+				<th data-o-table-heading-disable-sort data-o-table-data-type="numeric" class="o-table__cell--numeric o-registry-ui__table-cell--show">Version</th>
+				<th data-o-table-heading-disable-sort class="o-registry-ui__table-cell--show">Status</th>
 			</tr>
 		</thead>
 		<tbody class="o-registry-ui__table-body">

--- a/views/components.html
+++ b/views/components.html
@@ -14,25 +14,29 @@
 			</tr>
 		</thead>
 		<tbody class="o-registry-ui__table-body">
-			{{#each components}}
-				<tr style="cursor:pointer;">
-					<td>
-						<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
-						<p class='o-registry-ui__table-cell--description'>{{description}}
-							<span class='o-registry-ui__table-cell--info' aria-hidden='true'>v{{version}}
-								<span class="o-registry-ui__table-cell-label o-registry-ui__table-cell-label--{{support.status}}">{{support.status}}</span>
-							</span>
-						</p>
-					</td>
-					<td data-o-table-data-type="numeric" class='o-table__cell--numeric o-registry-ui__table-cell--show'>{{version}}</td>
-					<td class='o-registry-ui__table-cell--show'>
-						<span class="o-registry-ui__table-cell-label o-registry-ui__table-cell-label--{{support.status}}">
-							{{support.status}}
-						</span>
-					</td>
+			{{#each categories}}
+				<tr class="o-registry-ui__group-title">
+					<td colspan="3">{{capitalise @key}}</td>
 				</tr>
+				{{#each this}}
+					<tr>
+						<td>
+							<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
+							<p class='o-registry-ui__table-cell--description'>{{description}}
+								<span class='o-registry-ui__table-cell--info' aria-hidden='true'>v{{version}}
+									<span class="o-registry-ui__table-cell-label o-registry-ui__table-cell-label--{{support.status}}">{{support.status}}</span>
+								</span>
+							</p>
+						</td>
+						<td data-o-table-data-type="numeric" class='o-table__cell--numeric o-registry-ui__table-cell--show'>{{version}}</td>
+						<td class='o-registry-ui__table-cell--show'>
+							<span class="o-registry-ui__table-cell-label o-registry-ui__table-cell-label--{{support.status}}">
+								{{support.status}}
+							</span>
+						</td>
+					</tr>
+				{{/each}}
 			{{/each}}
 		</tbody>
 	</table>
-
 </div>

--- a/views/components.html
+++ b/views/components.html
@@ -3,24 +3,30 @@
 
 <p class="wip-notice">⚠️ This is a work in progress ⚠️</p>
 
-<table class="o-table o-registry-ui__table" data-o-component='o-table' data-test="component-table">
-	<thead class="o-registry-ui__table-head">
-		<tr>
-			<th>Name</th>
-			<th data-o-table-data-type="numeric" class='o-table__cell--numeric'>Version</th>
-			<th>Status</th>
-		</tr>
-	</thead>
-	<tbody class="o-registry-ui__table-body">
-		{{#each components}}
+<div class="o-registry-ui__overview">
+
+	<table class="o-table o-registry-ui__table" data-o-component='o-table' data-test="component-table">
+		<thead class="o-registry-ui__table-head">
 			<tr>
-				<td>
-					<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
-					<p class='o-registry-ui__table-cell--description'>{{description}}</p>
-				</td>
-				<td data-o-table-data-type="numeric" class='o-table__cell--numeric'>{{version}}</td>
-				<td>{{support.status}}</td>
+				<th>Component</th>
+				<th data-o-table-data-type="numeric" class='o-table__cell--numeric o-registry-ui__table-cell--show'>Version</th>
+				<th class="o-registry-ui__table-cell--show">Status</th>
 			</tr>
-		{{/each}}
-	</tbody>
-</table>
+		</thead>
+		<tbody class="o-registry-ui__table-body">
+			{{#each components}}
+				<tr>
+					<td>
+						<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
+						<p class='o-registry-ui__table-cell--description'>{{description}}
+							<span class='o-registry-ui__table-cell--info' aria-hidden='true'>v{{version}} — {{support.status}}</span>
+						</p>
+					</td>
+					<td data-o-table-data-type="numeric" class='o-table__cell--numeric o-registry-ui__table-cell--show'>{{version}}</td>
+					<td class='o-registry-ui__table-cell--show'>{{support.status}}</td>
+				</tr>
+			{{/each}}
+		</tbody>
+	</table>
+
+</div>

--- a/views/components.html
+++ b/views/components.html
@@ -7,10 +7,10 @@
 
 	<table class="o-table o-registry-ui__table" data-o-component='o-table' data-test="component-table">
 		<thead class="o-registry-ui__table-head">
-			<tr class="o-registry-ui__table-cell--show">
-				<th>Component</th>
-				<th data-o-table-data-type="numeric" class='o-table__cell--numeric'>Version</th>
-				<th>Status</th>
+			<tr>
+				<th class="o-registry-ui__table-cell--show">Component</th>
+				<th data-o-table-data-type="numeric" class="o-table__cell--numeric o-registry-ui__table-cell--show">Version</th>
+				<th class="o-registry-ui__table-cell--show">Status</th>
 			</tr>
 		</thead>
 		<tbody class="o-registry-ui__table-body">
@@ -19,11 +19,17 @@
 					<td>
 						<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
 						<p class='o-registry-ui__table-cell--description'>{{description}}
-							<span class='o-registry-ui__table-cell--info' aria-hidden='true'>v{{version}} — {{support.status}}</span>
+							<span class='o-registry-ui__table-cell--info' aria-hidden='true'>v{{version}}
+								<span class="o-registry-ui__table-cell-label o-registry-ui__table-cell-label--{{support.status}}">{{support.status}}</span>
+							</span>
 						</p>
 					</td>
 					<td data-o-table-data-type="numeric" class='o-table__cell--numeric o-registry-ui__table-cell--show'>{{version}}</td>
-					<td class='o-registry-ui__table-cell--show'>{{support.status}}</td>
+					<td class='o-registry-ui__table-cell--show'>
+						<span class="o-registry-ui__table-cell-label o-registry-ui__table-cell-label--{{support.status}}">
+							{{support.status}}
+						</span>
+					</td>
 				</tr>
 			{{/each}}
 		</tbody>

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -28,7 +28,7 @@
 
 	{{> header/main }}
 
-	<main role="main" class="typography-wrapper">
+	<main role="main">
 		{{{ body }}}
 	</main>
 

--- a/views/overview.html
+++ b/views/overview.html
@@ -1,0 +1,9 @@
+
+<!-- Beautiful temporary example markup -->
+
+<p class="wip-notice">⚠️ This is a work in progress ⚠️</p>
+
+<div class="o-registry-ui__overview">
+	{{> overview/component-table}}
+	{{> overview/sidebar }}
+</div>

--- a/views/overview.html
+++ b/views/overview.html
@@ -1,6 +1,3 @@
-
-<!-- Beautiful temporary example markup -->
-
 <p class="wip-notice">⚠️ This is a work in progress ⚠️</p>
 
 <div class="o-registry-ui__overview">

--- a/views/partials/overview/component-table.html
+++ b/views/partials/overview/component-table.html
@@ -13,7 +13,7 @@
 					<td colspan="3">{{capitalise @key}}</td>
 				</tr>
 				{{#each this}}
-					<tr>
+					<tr data-test="component-row">
 						<td>
 							<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
 							<p class='o-registry-ui__table-cell--description'>{{description}}

--- a/views/partials/overview/component-table.html
+++ b/views/partials/overview/component-table.html
@@ -1,10 +1,4 @@
-
-<!-- Beautiful temporary example markup -->
-
-<p class="wip-notice">⚠️ This is a work in progress ⚠️</p>
-
-<div class="o-registry-ui__overview">
-
+<div class="o-registry-ui__components">
 	<table class="o-table o-registry-ui__table" data-o-component='o-table' data-test="component-table">
 		<thead class="o-registry-ui__table-head">
 			<tr>

--- a/views/partials/overview/sidebar.html
+++ b/views/partials/overview/sidebar.html
@@ -1,0 +1,34 @@
+<div class="o-registry-ui__sidebar">
+	<div class="o-registry-ui__sidebar--content">
+		<p>The registry is updated whenever a new tag is pushed to a repository that has an <code>origami.json</code> file in it. If your repository meets the following criteria then it should be ingested within 5 minutes:</p>
+
+		<ul>
+			<li>
+				It lives in the
+				<a href="https://github.com/Financial-Times">Financial-Times GitHub organisation</a>
+			</li>
+			<li>
+				It contains a valid <code>origami.json</code> file
+				(see <a href="http://origami.ft.com/docs/syntax/origamijson/">the spec</a> for more information)
+			</li>
+			<li>
+				It has at least one git tag which complies with
+				<a href="https://semver.org/">semantic versioning</a>
+			</li>
+		</ul>
+
+		<h2>Registry API</h2>
+
+			<p>The Origami components library provides a read-only API conforming to the Bower Registry API spec (excluding registration and publishing).  To specify the Origami components library as your source for Bower components, create a <code>.bowerrc</code> file in your home directory or the root of your project's working tree, with the following content:</p>
+
+<pre>
+{
+  "registry": {
+    "search": [
+      "https://origami-bower-registry.ft.com",
+      "https://registry.bower.io"
+    ]
+  }
+}</pre>
+	</div>
+</div>

--- a/views/partials/overview/sidebar.html
+++ b/views/partials/overview/sidebar.html
@@ -1,5 +1,6 @@
 <div class="o-registry-ui__sidebar">
 	<div class="o-registry-ui__sidebar--content">
+		<h2>Library Updates</h2>
 		<p>The registry is updated whenever a new tag is pushed to a repository that has an <code>origami.json</code> file in it. If your repository meets the following criteria then it should be ingested within 5 minutes:</p>
 
 		<ul>

--- a/views/partials/overview/sidebar.html
+++ b/views/partials/overview/sidebar.html
@@ -18,7 +18,7 @@
 			</li>
 		</ul>
 
-		<h2>Registry API</h2>
+		<h2>Bower Registry</h2>
 
 			<p>The Origami components library provides a read-only API conforming to the Bower Registry API spec (excluding registration and publishing).  To specify the Origami components library as your source for Bower components, create a <code>.bowerrc</code> file in your home directory or the root of your project's working tree, with the following content:</p>
 


### PR DESCRIPTION
This styles the registry's overview closely to the original, as requested in #23.

<img width="1280" alt="screen shot 2018-02-20 at 15 00 41" src="https://user-images.githubusercontent.com/16777943/36431203-dd094ce2-164e-11e8-92f0-e33773ca419b.png">

It includes small changes:
- new colors (mostly grey) have been added to the service's palette
- table is more responsive
- side bar is sticky

Overall I've kept it the same but stripped out some colour.
Thoughts, objections, approvals & opinions all welcome. 

Closes #23 