### PR TITLE
Add cache-control headers

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -5,9 +5,10 @@ const httpError = require('http-errors');
 
 module.exports = app => {
 
-	// TODO this is temporary, we'll work out caching properly later
-	const neverCache = cacheControl({
-		maxAge: 0
+	const cacheForFiveMinutes = cacheControl({
+		maxAge: '5 minutes',
+		staleWhileRevalidate: '7 days',
+		staleIfError: '7 days'
 	});
 
 	const categoriseRepos = async () => {
@@ -43,7 +44,7 @@ module.exports = app => {
 	};
 
 	// Component listing page
-	app.get('/components', neverCache, async (request, response, next) => {
+	app.get('/components', cacheForFiveMinutes, async (request, response, next) => {
 		try {
 			response.render('overview', {
 				title: `Components - ${app.origami.options.name}`,
@@ -55,7 +56,7 @@ module.exports = app => {
 	});
 
 	// Individual component page
-	app.get('/components/:componentId', neverCache, async (request, response, next) => {
+	app.get('/components/:componentId', cacheForFiveMinutes, async (request, response, next) => {
 		try {
 			const [componentName, componentVersion] = request.params.componentId.split('@');
 

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -1,9 +1,17 @@
 'use strict';
 
+const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
+
 module.exports = app => {
 
+	const cacheForOneDay = cacheControl({
+		maxAge: '1 day',
+		staleWhileRevalidate: '7 days',
+		staleIfError: '7 days'
+	});
+
 	// Redirect to the components page
-	app.get('/', (request, response) => {
+	app.get('/', cacheForOneDay, (request, response) => {
 		response.redirect(301, `${request.basePath}components`);
 	});
 


### PR DESCRIPTION
I'm caching most things for just 5 minutes now, we can increase if we
need to later. This will balance keeping origin traffic low but the site
will still update frequently.

I've also used stale-while-revalidate and stale-on-error headers so that
a user never has to wait for origin while the cache is warmed up.