### PR TITLE
Click helper

### DIFF
--- a/src/js/click-helper.js
+++ b/src/js/click-helper.js
@@ -5,7 +5,14 @@ module.exports = (function() {
 	Array.from(links, link => {
 		const row = link.parentNode.parentNode;
 		if (link.href) {
-			row.addEventListener('click', () => { location.href = link.href; });
+			row.addEventListener('click', (e) => { 
+				e.preventDefault();
+				if (e.metaKey || e.ctrlKey || e.which === 2) {
+					window.open(link.href, '_blank');
+				} else {
+					location.href = link.href; 
+				}
+			});
 		}
 	});
 }());

--- a/src/scss/_footer.scss
+++ b/src/scss/_footer.scss
@@ -3,6 +3,7 @@
 	background-color: oColorsGetPaletteColor('grey-5');
 	padding: 20px;
 	margin-top: auto;
+	margin-bottom: 20px;
 
 	&--content {
 		display: flex;

--- a/src/scss/overview/_table.scss
+++ b/src/scss/overview/_table.scss
@@ -15,7 +15,11 @@
 	td {
 		vertical-align: middle;
 	}
-
+	
+	.o-registry-ui__group {
+		cursor: pointer;
+	}
+	
 	.o-registry-ui__group-title {
 		border-bottom: 1px solid oColorsGetPaletteColor('grey-20');;
 
@@ -23,12 +27,6 @@
 			@include oTypographySansBold(0);
 			@include oTypographyPadding($top: 4, $bottom: 4);
 		}
-	}
-}
-
-.o-registry-ui__table-row {
-	&--hidden {
-		display: none;
 	}
 }
 

--- a/views/partials/component/container.html
+++ b/views/partials/component/container.html
@@ -18,7 +18,7 @@
 	<div class="o-registry-ui__component--support">
 		<div class="o-registry-ui__component--contact">
 		<h4>Support</h4>
-			<p><span>Email</span><a href="mailto:{{component.support.email}}?subject={{component.name}}">{{component.support.email}}</a></p>
+			<p><span>Email </span><a href="mailto:{{component.support.email}}?subject={{component.name}}">{{component.support.email}}</a></p>
 			{{#if component.support.channel}}
 			<p><span>Slack </span><a href="{{component.support.channel.url}}">{{component.support.channel.name}}</a></p>
 			{{/if}}

--- a/views/partials/overview/component-table.html
+++ b/views/partials/overview/component-table.html
@@ -58,7 +58,7 @@
 						<td colspan="3">{{name}}</td>
 					</tr>
 					{{#each repos}}
-						<tr data-test="component-row" {{#unless visible}}aria-hidden="true" class="o-registry-ui__table-row--hidden"{{/unless}}>
+						<tr data-test="component-row" class="o-registry-ui__group" {{#unless visible}}aria-hidden="true" class="o-registry-ui__table-row--hidden"{{/unless}}>
 							<td>
 								<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
 								<p class='o-registry-ui__table-cell--description'>{{description}}


### PR DESCRIPTION
Fixes the click helper that was overriding behaviour.
Now, if a meta key is used on click, open a new tab.
Closes #39 
