### PR TITLE
Add client-side filtering

### DIFF
--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -17,4 +17,8 @@ const replace = (value, string, options) => {
 	}
 };
 
-module.exports = { capitalise, ifEquals, replace };
+const json = (value) => {
+	return JSON.stringify(value);
+};
+
+module.exports = { capitalise, ifEquals, json, replace };

--- a/lib/repo-listing.js
+++ b/lib/repo-listing.js
@@ -10,6 +10,7 @@ const capitalize = require('lodash/capitalize');
 function buildRepoCategoryMap(categories) {
 	return categories.reduce((categoryMap, categoryId) => {
 		categoryMap[categoryId] = {
+			id: categoryId,
 			name: capitalize(categoryId),
 			visible: true,
 			repos: []
@@ -159,6 +160,15 @@ function markVisibilityByStatus(repos, statuses) {
 module.exports = {
 	buildCategoryMap: buildRepoCategoryMap,
 	categorise: categoriseRepos,
+	defaultFilter: {
+		active: true,
+		experimental: true,
+		imageset: true,
+		maintained: true,
+		module: true,
+		search: '',
+		service: true
+	},
 	markVisibilityBySearchTerm: markVisibilityBySearchTerm,
 	markVisibilityByStatus: markVisibilityByStatus,
 	markVisibilityByType: markVisibilityByType

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -20,16 +20,7 @@ module.exports = app => {
 
 			// Default the filter
 			const filterIsPresent = (request.query.search !== undefined);
-			const filter = (filterIsPresent ? request.query : {
-				active: true,
-				dead: true,
-				deprecated: true,
-				experimental: true,
-				imageset: true,
-				maintained: true,
-				module: true,
-				service: true
-			});
+			const filter = (filterIsPresent ? request.query : repoListing.defaultFilter);
 
 			// Update the repos based on whether they match filters
 			repos = repoListing.markVisibilityBySearchTerm(repos, filter.search);

--- a/src/js/component-listing.js
+++ b/src/js/component-listing.js
@@ -70,7 +70,7 @@ class ComponentListing {
 	 */
 	getComponents() {
 		const elements = this.listingElement.querySelectorAll('[data-o-component]');
-		return Array.from(elements).map(element => {
+		return Array.from(elements, element => {
 			return {
 				name: element.getAttribute('data-o-component'),
 				keywords: JSON.parse(element.getAttribute('data-o-component-keywords')),

--- a/src/js/component-listing.js
+++ b/src/js/component-listing.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const repoListing = require('../../lib/repo-listing');
+
+/**
+ * Represents a filterable component listing.
+ */
+class ComponentListing {
+
+	/**
+	 * Class constructor.
+	 * @param {HTMLElement} [listingElement] - The listing element in the DOM.
+	 */
+	constructor(listingElement) {
+		this.listingElement = listingElement;
+		this.components = this.getComponents();
+		this.categoryElements = this.getCategoryElements();
+		document.addEventListener('o.filterFormUpdate', this.handleFilterFormUpdateEvent.bind(this));
+	}
+
+	/**
+	 * Handle the filter form update event.
+	 */
+	handleFilterFormUpdateEvent(event) {
+		const filter = event.detail;
+
+		// Perform the visibility marking
+		this.components = this.components.map(component => {
+			delete component.visible;
+			return component;
+		});
+		this.components = repoListing.markVisibilityBySearchTerm(this.components, filter.search);
+		this.components = repoListing.markVisibilityByType(this.components, {
+			imageset: filter.imageset,
+			module: filter.module,
+			service: filter.service
+		});
+		this.components = repoListing.markVisibilityByStatus(this.components, {
+			active: filter.active,
+			dead: filter.dead,
+			deprecated: filter.deprecated,
+			experimental: filter.experimental,
+			maintained: filter.maintained
+		});
+
+		// Set classes and attributes
+		for (const component of this.components) {
+			if (component.visible) {
+				component.element.removeAttribute('aria-hidden');
+				component.element.classList.remove('o-registry-ui__group--hidden');
+			} else {
+				component.element.setAttribute('aria-hidden', 'true');
+				component.element.classList.add('o-registry-ui__group--hidden');
+			}
+		};
+		for (const [categoryName, category] of Object.entries(repoListing.categorise(this.components))) {
+			if (category.visible) {
+				this.categoryElements[categoryName].removeAttribute('aria-hidden');
+				this.categoryElements[categoryName].classList.remove('o-registry-ui__group--hidden');
+			} else {
+				this.categoryElements[categoryName].setAttribute('aria-hidden', 'true');
+				this.categoryElements[categoryName].classList.add('o-registry-ui__group--hidden');
+			}
+		}
+
+	}
+
+	/**
+	 * Get the list of components.
+	 */
+	getComponents() {
+		const elements = this.listingElement.querySelectorAll('[data-o-component]');
+		return Array.from(elements).map(element => {
+			return {
+				name: element.getAttribute('data-o-component'),
+				keywords: JSON.parse(element.getAttribute('data-o-component-keywords')),
+				type: element.getAttribute('data-o-component-type'),
+				subType: element.getAttribute('data-o-component-sub-type'),
+				support: {
+					status: element.getAttribute('data-o-component-support-status')
+				},
+				element
+			};
+		});
+	}
+
+	/**
+	 * Get the component categories.
+	 */
+	getCategoryElements() {
+		const elements = this.listingElement.querySelectorAll('[data-o-component-category]');
+		return Array.from(elements).reduce((categoryMap, element) => {
+			categoryMap[element.getAttribute('data-o-component-category')] = element;
+			return categoryMap;
+		}, {});
+	}
+
+	/**
+	 * Initialise listing components.
+	 * @param {(HTMLElement|String)} rootElement - The root element to intialise filter forms in, or a CSS selector for the root element.
+	 * @param {Object} [options={}] - An options object for configuring the filter forms.
+	 */
+	static init(rootElement, options) {
+		if (!rootElement) {
+			rootElement = document.body;
+		}
+
+		// If the rootElement isnt an HTMLElement, treat it as a selector
+		if (!(rootElement instanceof HTMLElement)) {
+			rootElement = document.querySelector(rootElement);
+		}
+
+		// If the rootElement is an HTMLElement (ie it was found in the document anywhere)
+		// AND the rootElement has the data-o-component=o-component-listing then initialise just 1 listing (this one)
+		if (rootElement instanceof HTMLElement && /\bo-component-listing\b/.test(rootElement.getAttribute('data-o-component'))) {
+			return new ComponentListing(rootElement, options);
+		}
+
+		// If the rootElement wasn't itself a listing, then find ALL of the child things that have the data-o-component=oComponentListing set
+		return Array.from(rootElement.querySelectorAll('[data-o-component="o-component-listing"]'), rootElement => new ComponentListing(rootElement, options));
+	}
+
+}
+
+// Exports
+module.exports = ComponentListing;

--- a/src/js/filter-form.js
+++ b/src/js/filter-form.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const repoListing = require('../../lib/repo-listing');
+
+// Simple debounce function for throttling input
+function debounce(fn, delay) {
+	let timer = null;
+	return function () {
+		const context = this;
+		const args = arguments;
+		clearTimeout(timer);
+		timer = setTimeout(() => {
+			fn.apply(context, args);
+		}, delay);
+	};
+}
+
+// Debounced static push state
+const debouncedPushState = debounce((data, url) => {
+	window.history.pushState(data, '', url);
+}, 600);
+
+// Simple query string parsing
+function parseQueryString(queryString) {
+	return queryString.replace(/^\?/, '').split('&').reduce((parsed, param) => {
+		const [key, ...value] = param.split('=');
+		parsed[decodeURIComponent(key)] = decodeURIComponent(value.join('='));
+		return parsed;
+	}, {});
+}
+
+/**
+ * Represents a filter form.
+ */
+class FilterForm {
+
+	/**
+	 * Class constructor.
+	 * @param {HTMLElement} [formElement] - The filter form element in the DOM.
+	 */
+	constructor(formElement) {
+		this.formElement = formElement;
+		this.inputs = Array.from(formElement.querySelectorAll('input'));
+		this.lastFilter = this.getUrlEncodedFilterValues();
+
+		this.alterBrowserHistory = Boolean(formElement.getAttribute('o-filter-form-browser-history'));
+		if (this.alterBrowserHistory) {
+			window.addEventListener('popstate', this.handlePopStateEvents.bind(this));
+		}
+
+		const handleFormChangeEvent = this.handleFormChangeEvent.bind(this);
+		this.formElement.addEventListener('submit', handleFormChangeEvent);
+		this.formElement.addEventListener('input', handleFormChangeEvent);
+		this.formElement.addEventListener('change', handleFormChangeEvent);
+	}
+
+	/**
+	 * Handle the form changing events.
+	 */
+	handleFormChangeEvent() {
+		const queryString = this.getUrlEncodedFilterValues();
+		if (this.lastFilter !== queryString) {
+			this.lastFilter = queryString;
+			this.triggerFilterEvent();
+			if (this.alterBrowserHistory) {
+				debouncedPushState({
+					oFilterFormFilters: this.getFilterValues()
+				}, `?${queryString}`);
+			}
+		}
+	}
+
+	/**
+	 * Handle the window push-state changing.
+	 */
+	handlePopStateEvents(event) {
+		let filter;
+		if (event.state && event.state.oFilterFormFilters) {
+			filter = event.state.oFilterFormFilters;
+		} else if (document.location.search) {
+			filter = parseQueryString(document.location.search);
+		} else {
+			filter = repoListing.defaultFilter;
+		}
+		this.setFilterValues(filter);
+		this.triggerFilterEvent();
+	}
+
+	/**
+	 * Trigger the filter event
+	 */
+	triggerFilterEvent() {
+		document.dispatchEvent(new CustomEvent('o.filterFormUpdate', {
+			detail: this.getFilterValues()
+		}));
+	}
+
+	/**
+	 * Set the filter values.
+	 */
+	setFilterValues(filter) {
+		this.inputs.forEach(input => {
+			const name = input.getAttribute('name');
+			if (name) {
+				if (input.getAttribute('type') === 'checkbox') {
+					input.checked = filter[name];
+				} else {
+					input.value = filter[name];
+				}
+			}
+		});
+	}
+
+	/**
+	 * Get the filter values.
+	 */
+	getFilterValues() {
+		return this.inputs.reduce((values, input) => {
+			const name = input.getAttribute('name');
+			if (name) {
+				if (input.getAttribute('type') === 'checkbox') {
+					values[name] = input.checked ? 'true' : '';
+				} else {
+					values[name] = input.value;
+				}
+			}
+			return values;
+		}, {});
+	}
+
+	/**
+	 * Get the filter values as a query string.
+	 */
+	getUrlEncodedFilterValues() {
+		return Object.entries(this.getFilterValues())
+			.map(([key, value]) => {
+				return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+			})
+			.join('&');
+	}
+
+	/**
+	 * Initialise filter form components.
+	 * @param {(HTMLElement|String)} rootElement - The root element to intialise filter forms in, or a CSS selector for the root element.
+	 * @param {Object} [options={}] - An options object for configuring the filter forms.
+	 */
+	static init(rootElement, options) {
+		if (!rootElement) {
+			rootElement = document.body;
+		}
+
+		// If the rootElement isnt an HTMLElement, treat it as a selector
+		if (!(rootElement instanceof HTMLElement)) {
+			rootElement = document.querySelector(rootElement);
+		}
+
+		// If the rootElement is an HTMLElement (ie it was found in the document anywhere)
+		// AND the rootElement has the data-o-component=o-filter-form then initialise just 1 filter form (this one)
+		if (rootElement instanceof HTMLElement && /\bo-filter-form\b/.test(rootElement.getAttribute('data-o-component'))) {
+			return new FilterForm(rootElement, options);
+		}
+
+		// If the rootElement wasn't itself a filter form, then find ALL of the child things that have the data-o-component=oFilterForm set
+		return Array.from(rootElement.querySelectorAll('[data-o-component="o-filter-form"]'), rootElement => new FilterForm(rootElement, options));
+	}
+
+}
+
+// Exports
+module.exports = FilterForm;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -3,3 +3,19 @@
 require('./click-helper');
 require('./demo');
 require('./versioning');
+const ComponentListing = require('./component-listing');
+const FilterForm = require('./filter-form');
+
+// Initialise components
+document.addEventListener('o.DOMContentLoaded', () => {
+	ComponentListing.init();
+	FilterForm.init();
+});
+
+// Dispatch the o.DOMContentLoaded event
+if (document.readyState === 'interactive' || document.readyState === 'complete') {
+	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+}
+document.addEventListener('DOMContentLoaded', function() {
+	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+});

--- a/src/scss/overview/_table.scss
+++ b/src/scss/overview/_table.scss
@@ -15,11 +15,14 @@
 	td {
 		vertical-align: middle;
 	}
-	
+
 	.o-registry-ui__group {
 		cursor: pointer;
 	}
-	
+	.o-registry-ui__group--hidden {
+		display: none;
+	}
+
 	.o-registry-ui__group-title {
 		border-bottom: 1px solid oColorsGetPaletteColor('grey-20');;
 

--- a/test/unit/lib/repo-listing.test.js
+++ b/test/unit/lib/repo-listing.test.js
@@ -28,16 +28,19 @@ describe('lib/repo-listing', () => {
 		it('returns the expected category map', () => {
 			assert.deepEqual(returnValue, {
 				category: {
+					id: 'category',
 					name: 'Category',
 					visible: true,
 					repos: []
 				},
 				example: {
+					id: 'example',
 					name: 'Example',
 					visible: true,
 					repos: []
 				},
 				mock: {
+					id: 'mock',
 					name: 'Mock',
 					visible: true,
 					repos: []

--- a/views/partials/overview/component-table.html
+++ b/views/partials/overview/component-table.html
@@ -1,7 +1,7 @@
 <div class="o-registry-ui__components">
 
 	<!-- TODO move to a partial or find a new place for this -->
-	<form action="/components" method="get" class="o-registry-ui__form">
+	<form action="/components" method="get" class="o-registry-ui__form" data-o-component="o-filter-form" o-filter-form-browser-history="true">
 
 		<div class="o-forms o-forms--wide">
 			<label for="filter-search" class="o-forms__label">Filter components</label>
@@ -51,14 +51,14 @@
 				<th data-o-table-heading-disable-sort class="o-registry-ui__table-cell--show">Status</th>
 			</tr>
 		</thead>
-		<tbody class="o-registry-ui__table-body">
+		<tbody class="o-registry-ui__table-body" data-o-component="o-component-listing">
 			{{#each categories}}
 				{{#if repos.length}}
-					<tr class="o-registry-ui__group-title {{#unless visible}}o-registry-ui__table-row--hidden{{/unless}}" {{#unless visible}}aria-hidden="true"{{/unless}}>
+					<tr class="o-registry-ui__group-title {{#unless visible}}o-registry-ui__group--hidden{{/unless}}" {{#unless visible}}aria-hidden="true"{{/unless}} data-o-component-category="{{id}}">
 						<td colspan="3">{{name}}</td>
 					</tr>
 					{{#each repos}}
-						<tr data-test="component-row" class="o-registry-ui__group" {{#unless visible}}aria-hidden="true" class="o-registry-ui__table-row--hidden"{{/unless}}>
+						<tr data-test="component-row" class="o-registry-ui__group {{#unless visible}}o-registry-ui__group--hidden{{/unless}}" {{#unless visible}}aria-hidden="true"{{/unless}} data-o-component="{{name}}" data-o-component-keywords="{{json keywords}}" data-o-component-type="{{type}}" data-o-component-sub-type="{{subType}}" data-o-component-support-status="{{support.status}}">
 							<td>
 								<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
 								<p class='o-registry-ui__table-cell--description'>{{description}}


### PR DESCRIPTION
The filter form now works client-side as well as server side. I've
shared as much logic as possible between the two, and the client-side
version uses push-state so that when you reload the page or send the
link to somebody the same filtering is applied.