### PR TITLE
Add a filter form to the component page sidebar

### DIFF
--- a/src/js/component-listing.js
+++ b/src/js/component-listing.js
@@ -26,40 +26,46 @@ class ComponentListing {
 
 		// Perform the visibility marking
 		this.components = this.components.map(component => {
-			delete component.visible;
+			component.visible = true;
 			return component;
 		});
-		this.components = repoListing.markVisibilityBySearchTerm(this.components, filter.search);
-		this.components = repoListing.markVisibilityByType(this.components, {
-			imageset: filter.imageset,
-			module: filter.module,
-			service: filter.service
-		});
-		this.components = repoListing.markVisibilityByStatus(this.components, {
-			active: filter.active,
-			dead: filter.dead,
-			deprecated: filter.deprecated,
-			experimental: filter.experimental,
-			maintained: filter.maintained
-		});
+		if (filter.search !== undefined) {
+			this.components = repoListing.markVisibilityBySearchTerm(this.components, filter.search);
+		}
+		if (filter.module !== undefined) {
+			this.components = repoListing.markVisibilityByType(this.components, {
+				imageset: filter.imageset,
+				module: filter.module,
+				service: filter.service
+			});
+		}
+		if (filter.active !== undefined) {
+			this.components = repoListing.markVisibilityByStatus(this.components, {
+				active: filter.active,
+				dead: filter.dead,
+				deprecated: filter.deprecated,
+				experimental: filter.experimental,
+				maintained: filter.maintained
+			});
+		}
 
 		// Set classes and attributes
 		for (const component of this.components) {
 			if (component.visible) {
 				component.element.removeAttribute('aria-hidden');
-				component.element.classList.remove('o-registry-ui__group--hidden');
+				component.element.classList.remove('o-registry-ui__component-listing--hidden');
 			} else {
 				component.element.setAttribute('aria-hidden', 'true');
-				component.element.classList.add('o-registry-ui__group--hidden');
+				component.element.classList.add('o-registry-ui__component-listing--hidden');
 			}
-		};
+		}
 		for (const [categoryName, category] of Object.entries(repoListing.categorise(this.components))) {
 			if (category.visible) {
 				this.categoryElements[categoryName].removeAttribute('aria-hidden');
-				this.categoryElements[categoryName].classList.remove('o-registry-ui__group--hidden');
+				this.categoryElements[categoryName].classList.remove('o-registry-ui__component-listing--hidden');
 			} else {
 				this.categoryElements[categoryName].setAttribute('aria-hidden', 'true');
-				this.categoryElements[categoryName].classList.add('o-registry-ui__group--hidden');
+				this.categoryElements[categoryName].classList.add('o-registry-ui__component-listing--hidden');
 			}
 		}
 
@@ -75,7 +81,7 @@ class ComponentListing {
 				name: element.getAttribute('data-o-component'),
 				keywords: JSON.parse(element.getAttribute('data-o-component-keywords')),
 				type: element.getAttribute('data-o-component-type'),
-				subType: element.getAttribute('data-o-component-sub-type'),
+				subType: element.getAttribute('data-o-component-sub-type') || null,
 				support: {
 					status: element.getAttribute('data-o-component-support-status')
 				},

--- a/src/js/filter-form.js
+++ b/src/js/filter-form.js
@@ -43,7 +43,7 @@ class FilterForm {
 		this.inputs = Array.from(formElement.querySelectorAll('input'));
 		this.lastFilter = this.getUrlEncodedFilterValues();
 
-		this.alterBrowserHistory = Boolean(formElement.getAttribute('o-filter-form-browser-history'));
+		this.alterBrowserHistory = Boolean(formElement.getAttribute('data-o-filter-form-browser-history'));
 		if (this.alterBrowserHistory) {
 			window.addEventListener('popstate', this.handlePopStateEvents.bind(this));
 		}
@@ -57,7 +57,8 @@ class FilterForm {
 	/**
 	 * Handle the form changing events.
 	 */
-	handleFormChangeEvent() {
+	handleFormChangeEvent(event) {
+		event.preventDefault();
 		const queryString = this.getUrlEncodedFilterValues();
 		if (this.lastFilter !== queryString) {
 			this.lastFilter = queryString;

--- a/src/main.scss
+++ b/src/main.scss
@@ -28,6 +28,7 @@ $o-normalise-is-silent: false;
 @import 'src/scss/component/main';
 @import 'src/scss/form';
 @import 'src/scss/error';
+@import 'src/scss/component-listing';
 
 @include oFontsInclude(MetricWeb, regular);
 @include oFontsInclude(MetricWeb, semibold);

--- a/src/scss/_component-listing.scss
+++ b/src/scss/_component-listing.scss
@@ -1,0 +1,4 @@
+
+.o-registry-ui__component-listing--hidden {
+	display: none;
+}

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -2,3 +2,9 @@
 .o-registry-ui__form {
 	@include oTypographySans(0);
 }
+
+.o-registry-ui__form--nav {
+	@include oTypographyPadding($top: 5, $bottom: 0);
+	padding-left: 6px;
+	padding-right: 6px;
+}

--- a/src/scss/component/_list.scss
+++ b/src/scss/component/_list.scss
@@ -7,6 +7,7 @@
 .o-registry-ui__component--list {
 	list-style: none;
 	padding: 0 24px;
+	margin: 0;
 }
 
 .o-registry-ui__component--list-title {

--- a/src/scss/overview/_table.scss
+++ b/src/scss/overview/_table.scss
@@ -19,9 +19,6 @@
 	.o-registry-ui__group {
 		cursor: pointer;
 	}
-	.o-registry-ui__group--hidden {
-		display: none;
-	}
 
 	.o-registry-ui__group-title {
 		border-bottom: 1px solid oColorsGetPaletteColor('grey-20');;

--- a/views/partials/component/nav-bar.html
+++ b/views/partials/component/nav-bar.html
@@ -1,9 +1,15 @@
 <div class="o-registry-ui__component--nav">
-	<ul class="o-registry-ui__component--list">
+	<form class="o--if-js o-registry-ui__form o-registry-ui__form--nav" action="{{requestUrl}}" method="get" data-o-component="o-filter-form">
+		<div class="o-forms">
+			<label for="filter-search" class="o-forms__label">Filter components</label>
+			<input id="filter-search" type="search" name="search" value="" autocomplete="off" class="o-forms__text"/>
+		</div>
+	</form>
+	<ul class="o-registry-ui__component--list" data-o-component="o-component-listing">
 		{{#each categories}}
-			<li class="o-registry-ui__component--list-title">{{name}}</li>
+			<li class="o-registry-ui__component--list-title" data-o-component-category="{{id}}">{{name}}</li>
 			{{#each repos}}
-				<li class="o-registry-ui__component--list-item">
+				<li class="o-registry-ui__component--list-item" data-o-component="{{name}}" data-o-component-keywords="{{json keywords}}" data-o-component-type="{{type}}" data-o-component-sub-type="{{subType}}">
 					<a href="/components/{{name}}@{{version}}">{{name}}</a>
 				</li>
 			{{/each}}

--- a/views/partials/overview/component-table.html
+++ b/views/partials/overview/component-table.html
@@ -1,7 +1,7 @@
 <div class="o-registry-ui__components">
 
 	<!-- TODO move to a partial or find a new place for this -->
-	<form action="/components" method="get" class="o-registry-ui__form" data-o-component="o-filter-form" o-filter-form-browser-history="true">
+	<form action="/components" method="get" class="o-registry-ui__form" data-o-component="o-filter-form" data-o-filter-form-browser-history="true">
 
 		<div class="o-forms o-forms--wide">
 			<label for="filter-search" class="o-forms__label">Filter components</label>
@@ -54,11 +54,11 @@
 		<tbody class="o-registry-ui__table-body" data-o-component="o-component-listing">
 			{{#each categories}}
 				{{#if repos.length}}
-					<tr class="o-registry-ui__group-title {{#unless visible}}o-registry-ui__group--hidden{{/unless}}" {{#unless visible}}aria-hidden="true"{{/unless}} data-o-component-category="{{id}}">
+					<tr class="o-registry-ui__group-title {{#unless visible}}o-registry-ui__component-listing--hidden{{/unless}}" {{#unless visible}}aria-hidden="true"{{/unless}} data-o-component-category="{{id}}">
 						<td colspan="3">{{name}}</td>
 					</tr>
 					{{#each repos}}
-						<tr data-test="component-row" class="o-registry-ui__group {{#unless visible}}o-registry-ui__group--hidden{{/unless}}" {{#unless visible}}aria-hidden="true"{{/unless}} data-o-component="{{name}}" data-o-component-keywords="{{json keywords}}" data-o-component-type="{{type}}" data-o-component-sub-type="{{subType}}" data-o-component-support-status="{{support.status}}">
+						<tr data-test="component-row" class="o-registry-ui__group {{#unless visible}}o-registry-ui__component-listing--hidden{{/unless}}" {{#unless visible}}aria-hidden="true"{{/unless}} data-o-component="{{name}}" data-o-component-keywords="{{json keywords}}" data-o-component-type="{{type}}" data-o-component-sub-type="{{subType}}" data-o-component-support-status="{{support.status}}">
 							<td>
 								<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
 								<p class='o-registry-ui__table-cell--description'>{{description}}


### PR DESCRIPTION
This reuses the code from the existing filter on the overview page, but
without any of the push-state stuff.