### PR TITLE
Only show active and maintained repos

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -99,10 +99,18 @@ module.exports = app => {
 			// Augment the component object with a major version number, for use in image sets
 			component.majorVersion = component.version;
 
+			// Load and filter all repositories for use in the sidebar
+			const repos = (await app.repoData.listRepos()).filter(repo => {
+				return (
+					repo.support.status === 'active' ||
+					repo.support.status === 'maintained'
+				);
+			});
+
 			// Render the component page
 			response.render('component', {
 				title: `${component.name} - ${app.origami.options.name}`,
-				categories: repoListing.categorise(await app.repoData.listRepos()),
+				categories: repoListing.categorise(repos),
 				component,
 				demos,
 				images,


### PR DESCRIPTION
The side nav on the component page is too long, and includes deprecated
components with no indication that they're deprecated. I'm limiting this
list to active and maintained components, which also matches the way the
current registry does things.