### PR TITLE
Add IDs to headings and auto-link them

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "o-normalise": "^1.5.3",
     "o-tabs": "^4.0.4",
     "o-forms": "^5.2.1",
-    "o-overlay": "^2.3.0"
+    "o-overlay": "^2.3.0",
+    "o-visual-effects": "^2.0.3"
   }
 }

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -17,8 +17,22 @@ const replace = (value, string, options) => {
 	}
 };
 
+const slugify = (value) => {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9\-\s]+/g, '')
+		.replace(/\s+/g, '-');
+};
+
 const json = (value) => {
 	return JSON.stringify(value);
 };
 
-module.exports = { capitalise, ifEquals, json, replace };
+module.exports = {
+	capitalise,
+	ifEquals,
+	json,
+	replace,
+	slugify
+};

--- a/src/js/linked-heading.js
+++ b/src/js/linked-heading.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * Represents a filterable component heading.
+ */
+class LinkedHeading {
+
+	/**
+	 * Class constructor.
+	 * @param {HTMLElement} [headingElement] - The heading element in the DOM.
+	 */
+	constructor(headingElement) {
+		this.headingElement = headingElement;
+		this.id = headingElement.getAttribute('id');
+		this.buildLink();
+	}
+
+	/**
+	 * Build the heading link.
+	 */
+	buildLink() {
+		if (this.id) {
+			this.link = document.createElement('a');
+			this.link.setAttribute('href', `#${this.id}`);
+			this.link.setAttribute('title', 'Link directly to this section of the page');
+			this.link.innerHTML = '&nbsp;¶';
+			this.link.classList.add('o-registry-ui__linked-heading__permalink');
+			this.headingElement.innerHTML = this.headingElement.innerHTML.trim();
+			this.headingElement.appendChild(this.link);
+		}
+	}
+
+	/**
+	 * Initialise heading components.
+	 * @param {(HTMLElement|String)} rootElement - The root element to intialise filter forms in, or a CSS selector for the root element.
+	 * @param {Object} [options={}] - An options object for configuring the heading.
+	 */
+	static init(rootElement, options) {
+		if (!rootElement) {
+			rootElement = document.body;
+		}
+
+		// If the rootElement isnt an HTMLElement, treat it as a selector
+		if (!(rootElement instanceof HTMLElement)) {
+			rootElement = document.querySelector(rootElement);
+		}
+
+		// If the rootElement is an HTMLElement (ie it was found in the document anywhere)
+		// AND the rootElement has the data-o-component=o-linked-heading then initialise just 1 heading (this one)
+		if (rootElement instanceof HTMLElement && /\bo-linked-heading\b/.test(rootElement.getAttribute('data-o-component'))) {
+			return new LinkedHeading(rootElement, options);
+		}
+
+		// If the rootElement wasn't itself a heading, then find ALL of the child things that have the data-o-component=oLinkedHeading set
+		return Array.from(rootElement.querySelectorAll('[data-o-component="o-linked-heading"]'), rootElement => new LinkedHeading(rootElement, options));
+	}
+
+}
+
+// Exports
+module.exports = LinkedHeading;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,12 +8,14 @@ require('./versioning');
 const ComponentListing = require('./component-listing');
 const FilterForm = require('./filter-form');
 const hljs = require('highlight.js');
+const LinkedHeading = require('./linked-heading');
 
 // Initialise components
 document.addEventListener('o.DOMContentLoaded', () => {
 	ComponentListing.init();
 	FilterForm.init();
 	hljs.initHighlighting();
+	LinkedHeading.init();
 });
 
 // Dispatch the o.DOMContentLoaded event

--- a/src/main.scss
+++ b/src/main.scss
@@ -18,6 +18,7 @@ $o-normalise-is-silent: false;
 @import 'o-table/main';
 @import 'o-tabs/main';
 @import 'o-typography/main';
+@import 'o-visual-effects/main';
 
 // Includes.
 @import 'src/scss/colors';

--- a/src/scss/component/_linked-heading.scss
+++ b/src/scss/component/_linked-heading.scss
@@ -1,0 +1,32 @@
+
+.o-registry-ui__linked-heading {
+
+	&:target {
+		animation-delay: 0;
+		animation-duration: 5s;
+		animation-timing-function: $o-visual-effects-transition-fade;
+  		animation-name: o-linked-heading-fade;
+	}
+
+	&__permalink,
+	&__permalink:visited {
+		color: oColorsGetColorFor(link, text);
+		text-decoration: none;
+		display: none;
+		user-select: none;
+	}
+
+	&:hover &__permalink {
+		display: inline-block;
+	}
+
+}
+
+@keyframes o-linked-heading-fade {
+	0% {
+		background-color: oColorsMix('lemon', 'white', 30);
+	}
+	100% {
+		background-color: transparent;
+	}
+}

--- a/src/scss/component/main.scss
+++ b/src/scss/component/main.scss
@@ -3,6 +3,7 @@
 @import 'src/scss/component/syntax-highlight';
 @import 'src/scss/component/container';
 @import 'src/scss/component/sidebar';
+@import 'src/scss/component/linked-heading';
 
 .o-registry-ui__component {
 	display: flex;

--- a/views/partials/component/container.html
+++ b/views/partials/component/container.html
@@ -18,7 +18,7 @@
 
 	<div class="o-registry-ui__component--support">
 		<div class="o-registry-ui__component--contact">
-		<h4>Support</h4>
+		<h4 id="support" data-o-component="o-linked-heading" class="o-registry-ui__linked-heading">Support</h4>
 			<p><span>Email </span><a href="mailto:{{component.support.email}}?subject={{component.name}}">{{component.support.email}}</a></p>
 			{{#if component.support.channel}}
 			<p><span>Slack </span><a href="{{component.support.channel.url}}">{{component.support.channel.name}}</a></p>

--- a/views/partials/component/type/demos.html
+++ b/views/partials/component/type/demos.html
@@ -1,7 +1,9 @@
 <div class="o-registry-ui__component--demo-container">
 	{{#demos}}
 		<div class="o-registry-ui__component--demo">
-			<h3 class="o-registry-ui__component--demo-title">{{capitalise title}}</h3>
+			<h3 class="o-registry-ui__component--demo-title o-registry-ui__linked-heading" id="demo-{{slugify title}}" data-o-component="o-linked-heading">
+				{{capitalise title}}
+			</h3>
 			{{#if description}}
 				<p class="o-registry-ui__component--demo-description">{{description}}</p>
 			{{/if}}


### PR DESCRIPTION
Now when you hover over certain headings on the component page, you get
a permalink to that heading. Resolves #57

![registry-linked-headings](https://user-images.githubusercontent.com/138944/36981903-46797e22-2086-11e8-8f7b-b83e9e5d4ea6.gif)
