### PR TITLE
Remove a conflicting attribute

### DIFF
--- a/src/js/component-listing.js
+++ b/src/js/component-listing.js
@@ -87,10 +87,10 @@ class ComponentListing {
 	 * Get the list of components.
 	 */
 	getComponents() {
-		const elements = this.listingElement.querySelectorAll('[data-o-component]');
+		const elements = this.listingElement.querySelectorAll('[data-o-component-name]');
 		return Array.from(elements, element => {
 			return {
-				name: element.getAttribute('data-o-component'),
+				name: element.getAttribute('data-o-component-name'),
 				keywords: JSON.parse(element.getAttribute('data-o-component-keywords')),
 				type: element.getAttribute('data-o-component-type'),
 				subType: element.getAttribute('data-o-component-sub-type') || null,

--- a/views/partials/component/nav-bar.html
+++ b/views/partials/component/nav-bar.html
@@ -9,7 +9,7 @@
 		{{#each categories}}
 			<li class="o-registry-ui__component--list-title" data-o-component-category="{{id}}">{{name}}</li>
 			{{#each repos}}
-				<li class="o-registry-ui__component--list-item" data-o-component="{{name}}" data-o-component-keywords="{{json keywords}}" data-o-component-type="{{type}}" data-o-component-sub-type="{{subType}}">
+				<li class="o-registry-ui__component--list-item" data-o-component-name="{{name}}" data-o-component-keywords="{{json keywords}}" data-o-component-type="{{type}}" data-o-component-sub-type="{{subType}}">
 					<a href="/components/{{name}}@{{version}}">{{name}}</a>
 				</li>
 			{{/each}}

--- a/views/partials/overview/component-table.html
+++ b/views/partials/overview/component-table.html
@@ -58,7 +58,7 @@
 						<td colspan="3">{{name}}</td>
 					</tr>
 					{{#each repos}}
-						<tr data-test="component-row" class="o-registry-ui__group {{#unless visible}}o-registry-ui__component-listing--hidden{{/unless}}" {{#unless visible}}aria-hidden="true"{{/unless}} data-o-component="{{name}}" data-o-component-keywords="{{json keywords}}" data-o-component-type="{{type}}" data-o-component-sub-type="{{subType}}" data-o-component-support-status="{{support.status}}">
+						<tr data-test="component-row" class="o-registry-ui__group {{#unless visible}}o-registry-ui__component-listing--hidden{{/unless}}" {{#unless visible}}aria-hidden="true"{{/unless}} data-o-component-name="{{name}}" data-o-component-keywords="{{json keywords}}" data-o-component-type="{{type}}" data-o-component-sub-type="{{subType}}" data-o-component-support-status="{{support.status}}">
 							<td>
 								<a class='o-registry-ui__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
 								<p class='o-registry-ui__table-cell--description'>{{description}}


### PR DESCRIPTION
In today's episode of Rowan is an Idiot, he named one of the attributes
used by the component filter "data-o-component". If that looks familiar,
it's because that's the name of the attribute we use to auto-bind
components to DOM elements.

So what was happening is: each table row on the component page was being
initialised as the component it's supposed to be linking to. So that
o-toggle error we've been seeing, it's because we were initialising a
toggle on a table row which _of course_ doesn't have a target.

So much facepalm.