### PR TITLE
Prevent the header drawer flash

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -15,11 +15,3 @@ document.addEventListener('o.DOMContentLoaded', () => {
 	FilterForm.init();
 	hljs.initHighlighting();
 });
-
-// Dispatch the o.DOMContentLoaded event
-if (document.readyState === 'interactive' || document.readyState === 'complete') {
-	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-}
-document.addEventListener('DOMContentLoaded', function() {
-	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-});

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,8 @@
 'use strict';
 
+require('./js/main');
 require('o-header-services');
 require('o-overlay');
 require('o-table');
 require('o-tabs');
 require('o-autoinit');
-
-require('./js/main');

--- a/views/partials/header/drawer.html
+++ b/views/partials/header/drawer.html
@@ -1,4 +1,4 @@
-<div class="o-registry-ui__drawer o-header__drawer--services o-header__drawer o--if-js" id="o-header-drawer" data-o-header-drawer="" data-o-header-drawer--no-js="">
+<div class="o-registry-ui__drawer o-header__drawer--services o-header__drawer o--if-js" id="o-header-drawer" data-o-header-drawer="" data-o-header-drawer--js="true" aria-hidden="true">
 	<div class="o-header__drawer-inner">
 		<div class="o-header__drawer-tools">
 			<span>{{ft.options.name}}</span>


### PR DESCRIPTION
The header drawer is visible for a short amount of time on page load,
before the JavaScript is included. I've added in the classes required to
hide it by default