### PR TITLE
remove highlight, add prism

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -5,6 +5,7 @@ const httpError = require('http-errors');
 const express = require('express');
 const requestUrl = require('request-promise-native');
 const repoListing = require('../repo-listing');
+const prism = require('prismjs');
 
 module.exports = app => {
 
@@ -85,9 +86,11 @@ module.exports = app => {
 			if (component.type === 'module' && component.resources.demos) {
 				demos = await app.repoData.listDemos(component.repo, component.id);
 
+			// fetch the plain HTML and higlight it so we can style it
 			try {
 				await Promise.all(demos.filter(demo => demo.display.html).map(async demo => {
 					demo.display.plainHTML = await requestUrl(demo.supportingUrls.html);
+					demo.display.highlightedHTML = prism.highlight(demo.display.plainHTML, prism.languages.html);
 				}));
 			} catch (error) {
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -746,6 +746,17 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clipboard": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+      "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
+      "optional": true,
+      "requires": {
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
+      }
+    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -1046,6 +1057,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -2740,6 +2757,15 @@
         }
       }
     },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
+      "requires": {
+        "delegate": "3.2.0"
+      }
+    },
     "got": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
@@ -2868,11 +2894,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/heroku-node-settings/-/heroku-node-settings-1.1.0.tgz",
       "integrity": "sha1-vUDWdhpvQ1iwCQ/njrVgyNRXkiE="
-    },
-    "highlight.js": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
     },
     "hoek": {
       "version": "4.2.0",
@@ -5829,6 +5850,14 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
+    "prismjs": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.11.0.tgz",
+      "integrity": "sha1-KXrvM+t5Qhv9sZJzpQkspRWXDSk=",
+      "requires": {
+        "clipboard": "1.7.1"
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -6191,6 +6220,12 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
     },
     "semver": {
       "version": "5.5.0",
@@ -6843,6 +6878,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
+      "optional": true
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "@financial-times/origami-service-makefile": "^6.1.0",
     "dotenv": "^4.0.0",
     "heroku-node-settings": "^1.1.0",
-    "highlight.js": "^9.12.0",
     "http-errors": "^1.6.2",
+    "prismjs": "^1.11.0",
     "request-promise-native": "^1.0.5",
     "require-all": "^2.2.0",
     "throng": "^4.0.0"

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -7,13 +7,11 @@ require('./versioning');
 
 const ComponentListing = require('./component-listing');
 const FilterForm = require('./filter-form');
-const hljs = require('highlight.js');
 const LinkedHeading = require('./linked-heading');
 
 // Initialise components
 document.addEventListener('o.DOMContentLoaded', () => {
 	ComponentListing.init();
 	FilterForm.init();
-	hljs.initHighlighting();
 	LinkedHeading.init();
 });

--- a/src/scss/component/_syntax-highlight.scss
+++ b/src/scss/component/_syntax-highlight.scss
@@ -6,34 +6,30 @@
 	tab-size: 4;
 
 	code {
+		display: block;
+		padding: 8px;
+		color: oColorsGetPaletteColor('grey-80');
+		overflow-x: auto;
 		font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
 		font-size: 14px;
 		white-space: inherit;
 	}
 }
 
-.hljs {
-	display: block;
-	padding: 0.5em;
-	color: oColorsGetPaletteColor('grey-80');
-	overflow-x: auto;
-}
+.token {
+	.tag {
+		color: oColorsGetPaletteColor('crimson-black-90');
+	}
 
-.hljs-attribute,
-.hljs-attr {
-	color: oColorsGetPaletteColor('mandarin-black-90');
-}
+	.punctuation {
+		color: oColorsGetPaletteColor('grey-80');
+	}
 
-.hljs-tag {
-	color: oColorsGetPaletteColor('grey-80');
-}
+	.attr-name {
+		color: oColorsGetPaletteColor('mandarin-black-90');
+	}
 
-.hljs-string,
-.hljs-value {
-	color: oColorsGetPaletteColor('wasabi-white-70')
-}
-
-.hljs-name,
-.hljs-title {
-	color: oColorsGetPaletteColor('crimson-black-90');
+	.attr-value {
+		color: oColorsGetPaletteColor('wasabi-white-70')
+	}
 }

--- a/views/partials/component/type/demos.html
+++ b/views/partials/component/type/demos.html
@@ -31,7 +31,7 @@
 					<div class="o-tabs__tabpanel" id="{{title}}-html-{{@index}}">
 						{{#if display.plainHTML}}
 							<button class="o-registry-ui__demo-button select-html">Select Full Code Snippet</button>
-							<pre class="demo__code"><code class='html'>{{display.plainHTML}}</code></pre>
+							<pre class="demo__code"><code class='html'>{{{display.highlightedHTML}}}</code></pre>
 						{{else}}
 							<iframe scrolling="yes" allowTransparency="true" src="{{supportingUrls.html}}" class="demo__code"></iframe>
 						{{/if}}


### PR DESCRIPTION
Yay for serverside highlighting, as @JakeChampion suggested.

PrismJS highlights plain HTML serverside, and we've just  added some styling to the classes that it generates, instead of fetching a minified file version. 

⚠️ Let's keep an eye out for HTML demos that are uncoloured/unstyled in case we missed any tag names that Prism adds ✌️ 