### PR TITLE
Colour contrast

### DIFF
--- a/src/js/click-helper.js
+++ b/src/js/click-helper.js
@@ -1,16 +1,16 @@
 'use strict';
 
 module.exports = (function() {
-	const links = document.querySelectorAll('.registry__table-cell--link');
+	const links = document.querySelectorAll('.registry__table-cell__link');
 	Array.from(links, link => {
 		const row = link.parentNode.parentNode;
 		if (link.href) {
-			row.addEventListener('click', (e) => { 
+			row.addEventListener('click', (e) => {
 				e.preventDefault();
 				if (e.metaKey || e.ctrlKey || e.which === 2) {
 					window.open(link.href, '_blank');
 				} else {
-					location.href = link.href; 
+					location.href = link.href;
 				}
 			});
 		}

--- a/src/js/click-helper.js
+++ b/src/js/click-helper.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = (function() {
-	const links = document.querySelectorAll('.registry__table-cell__link');
+	const links = document.querySelectorAll('.registry__table-cell-link');
 	Array.from(links, link => {
 		const row = link.parentNode.parentNode;
 		if (link.href) {

--- a/src/scss/_colors.scss
+++ b/src/scss/_colors.scss
@@ -1,5 +1,4 @@
 @include oColorsSetColor('slate-white-80', oColorsMix(slate, white, 80));
-@include oColorsSetColor('slate-white-60', oColorsMix(slate, white, 60));
 
 @include oColorsSetColor('crimson-black-90', oColorsMix(crimson, black, 90));
 @include oColorsSetColor('mandarin-black-90', oColorsMix(mandarin, black, 90));

--- a/src/scss/_media-queries.scss
+++ b/src/scss/_media-queries.scss
@@ -16,7 +16,7 @@
 		flex-basis: 20%;
 	}
 
-	.registry__table-cell--show {
+	.registry__table-cell-show {
 		display: table-cell;
 	}
 

--- a/src/scss/_status-labels.scss
+++ b/src/scss/_status-labels.scss
@@ -7,8 +7,8 @@
 
  	&--active,
 	&--maintained {
-		background-color: oColorsMix('jade', 'black', 80);
-		color: oColorsGetTextColor(oColorsMix('jade', 'black', 80), 100);
+		background-color: oColorsMix('jade', 'black', 70);
+		color: oColorsGetTextColor(oColorsMix('jade', 'black', 70), 100);
 	}
 
  	&--experimental {
@@ -19,5 +19,10 @@
  	&--deprecated {
 		background-color: oColorsGetPaletteColor('crimson');
 		color: oColorsGetTextColor(oColorsGetPaletteColor('crimson'), 100);
+	}
+
+ 	&--dead {
+		background-color: oColorsGetPaletteColor('black');
+		color: oColorsGetTextColor(oColorsGetPaletteColor('black'));
 	}
 }

--- a/src/scss/component/_header.scss
+++ b/src/scss/component/_header.scss
@@ -32,7 +32,7 @@
 			padding-right: 8px;
 
 			&:hover {
-				color: oColorsGetPaletteColor('slate-white-60');
+				color: oColorsGetPaletteColor('slate');
 			}
 
 			&:after {

--- a/src/scss/component/_list-sidebar.scss
+++ b/src/scss/component/_list-sidebar.scss
@@ -21,12 +21,14 @@
 	a {
 		@include oTypographyLinkCustom(
 			$baseColor: 'slate',
-			$hoverColor: 'slate-white-80',
+			$hoverColor: 'slate',
 			$backgroundColor: 'slate-white-5',
 			$outlineColor: 'teal-100'
-		)
+		);
 
-		border-bottom: none;
+		:not(:hover) {
+			border-bottom: none;
+		}
 	}
 }
 

--- a/src/scss/overview/_table.scss
+++ b/src/scss/overview/_table.scss
@@ -42,26 +42,24 @@
 	}
 }
 
-.registry__table-cell {
-	&--link {
-		@include oTypographySansBold(1);
-		text-decoration: none;
-		color: oColorsGetPaletteColor('slate-white-80');
-	}
-
-	&--description {
-		@include oTypographyMargin($top: 2, $bottom: 1);
-		color: oColorsGetPaletteColor('slate-white-60');
-		font-weight: 400;
-	}
-
-	&--show {
-		display: none;
-	}
-
-	&--info {
-		@include oTypographyPadding($top: 2);
-		display: table-cell;
-		color: oColorsGetPaletteColor('slate-white-80');
-	};
+.registry__table-cell-link {
+	@include oTypographySansBold(1);
+	text-decoration: none;
+	color: oColorsGetPaletteColor('slate-white-80');
 }
+
+.registry__table-cell-description {
+	@include oTypographyMargin($top: 2, $bottom: 1);
+	font-weight: 400;
+	color: oColorsGetPaletteColor('slate-white-80');
+}
+
+.registry__table-cell-show {
+	display: none;
+}
+
+.registry__table-cell-info {
+	@include oTypographyPadding($top: 2);
+	display: table-cell;
+	color: oColorsGetPaletteColor('slate-white-80');
+};

--- a/views/partials/overview/component-table.html
+++ b/views/partials/overview/component-table.html
@@ -5,9 +5,9 @@
 	<table class="o-table registry__table" data-o-component="o-table" data-test="component-table">
 		<thead class="registry__table-head">
 			<tr>
-				<th data-o-table-heading-disable-sort class="registry__table-cell--show">Component</th>
-				<th data-o-table-heading-disable-sort data-o-table-data-type="numeric" class="o-table__cell--numeric registry__table-cell--show">Version</th>
-				<th data-o-table-heading-disable-sort class="registry__table-cell--show">Status</th>
+				<th data-o-table-heading-disable-sort class="registry__table-cell-show">Component</th>
+				<th data-o-table-heading-disable-sort data-o-table-data-type="numeric" class="o-table__cell--numeric registry__table-cell-show">Version</th>
+				<th data-o-table-heading-disable-sort class="registry__table-cell-show">Status</th>
 			</tr>
 		</thead>
 		<tbody class="registry__table-body" data-o-component="o-component-listing">
@@ -19,15 +19,15 @@
 					{{#each repos}}
 						<tr data-test="component-row" class="registry__group {{#unless visible}}registry__component-listing--hidden{{/unless}}" {{#unless visible}}aria-hidden="true"{{/unless}} data-o-component-name="{{name}}" data-o-component-keywords="{{json keywords}}" data-o-component-type="{{type}}" data-o-component-sub-type="{{subType}}" data-o-component-support-status="{{support.status}}">
 							<td>
-								<a class='registry__table-cell--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
-								<p class='registry__table-cell--description'>{{description}}
+								<a class='registry__table-cell-link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
+								<p class='registry__table-cell-description'>{{description}}
 									<span class='registry__table-cell--info' aria-hidden='true'>v{{version}}
 										<span class="status-label status-label--{{support.status}}">{{support.status}}</span>
 									</span>
 								</p>
 							</td>
-							<td data-o-table-data-type="numeric" class='o-table__cell--numeric registry__table-cell--show'>{{version}}</td>
-							<td class='registry__table-cell--show'>
+							<td data-o-table-data-type="numeric" class='o-table__cell--numeric registry__table-cell-show'>{{version}}</td>
+							<td class='registry__table-cell-show'>
 								<span class="status-label status-label--{{support.status}}">
 									{{support.status}}
 								</span>


### PR DESCRIPTION
This improves colour contrast in a couple of places to WCAG AA standards.

Thanks for pointing out @JakeChampion.

**component page**
- Light links ("external links") go darker rather than lighter. 
- The sidebar links which can't go darker reintroduce the standard underline on hover instead.

![kapture 2018-03-28 at 11 52 10](https://user-images.githubusercontent.com/10405691/38025165-40245ea6-327f-11e8-9d40-4a4cc80e6475.gif)

**index page**
- Introduces a "dead" label.
- Darkens the "active" label.
- Darkens the description text.
<img width="873" alt="screen shot 2018-03-28 at 11 38 52" src="https://user-images.githubusercontent.com/10405691/38025198-688412a6-327f-11e8-92bd-f342c7517e10.png">

**other**
I've updated a couple of classes I came across to conform to BEM.