### PR TITLE
Add current brand to component links.

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -18,6 +18,7 @@ module.exports = app => {
 	app.get('/components', cacheForFiveMinutes, express.urlencoded({extended: false}), async (request, response, next) => {
 		try {
 			let repos = await app.repoData.listRepos();
+			const requestedBrand = (request.query.brand) ? request.query.brand : 'master';
 
 			// Default the filter
 			const filterIsPresent = (request.query.search !== undefined);
@@ -42,7 +43,8 @@ module.exports = app => {
 			response.render('overview', {
 				title: `Components - ${app.ft.options.name}`,
 				categories: repoListing.categorise(repos),
-				filter
+				filter,
+				requestedBrand: requestedBrand
 			});
 		} catch (error) {
 			next(error);

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -44,7 +44,7 @@ module.exports = app => {
 				title: `Components - ${app.ft.options.name}`,
 				categories: repoListing.categorise(repos),
 				filter,
-				requestedBrand: requestedBrand
+				requestedBrand
 			});
 		} catch (error) {
 			next(error);

--- a/views/partials/component/list-sidebar.html
+++ b/views/partials/component/list-sidebar.html
@@ -15,7 +15,7 @@
 					data-o-component-keywords="{{json keywords}}"
 					data-o-component-type="{{type}}"
 					data-o-component-sub-type="{{subType}}">
-					<a href="/components/{{name}}@{{version}}">{{name}}</a>
+					<a href="/components/{{name}}@{{version}}{{#unlessEquals @root.component.requestedBrand 'master' }}?brand={{ @root.component.requestedBrand }}{{/unlessEquals}}">{{name}}</a>
 				</li>
 			{{/repos}}
 		{{/if}}

--- a/views/partials/component/quickstart/build-service.html
+++ b/views/partials/component/quickstart/build-service.html
@@ -10,7 +10,7 @@
 				{{#if @root.component.hasCSS}}<code>&lt;link&gt;</code> tag{{/if}}
 			{{/ifBoth}}
 		</p>
-		<pre  class="overflow">{{@root.component.name}}@^{{@root.component.version}}{{#unlessEquals requestedBrand 'master'}}?brand={{requestedBrand}}{{/unlessEquals}}</pre>
+		<pre  class="overflow">{{@root.component.name}}@^{{@root.component.version}}{{#unlessEquals requestedBrand 'master'}}&brand={{requestedBrand}}{{/unlessEquals}}</pre>
 		<p><a class="o-overlay-trigger link"
 					data-o-overlay-id="overlay"
 					data-o-overlay-src="#how-do-i-build-service"
@@ -38,11 +38,11 @@
 			to your page:
 		</p>
 
-		<pre class="overflow">&lt;link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules={{@root.component.name}}@^{{@root.component.version}}{{#if requestedBrand}}?brand={{requestedBrand}}{{/if}}" /><br>&lt;script src="https://www.ft.com/__origami/service/build/v2/bundles/js?modules={{@root.component.name}}@^{{@root.component.version}}">&lt;/script></pre>
+		<pre class="overflow">&lt;link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules={{@root.component.name}}@^{{@root.component.version}}{{#if requestedBrand}}&brand={{requestedBrand}}{{/if}}" /><br>&lt;script src="https://www.ft.com/__origami/service/build/v2/bundles/js?modules={{@root.component.name}}@^{{@root.component.version}}">&lt;/script></pre>
 
 		<p>You should have <strong>only one</strong> (Origami related) <code>&lt;script&gt;</code> and one <code>&lt;link&gt;</code> tag in your page, even if you want to load more than one component. <br>You can request all <strong>{{#unlessEquals requestedBrand 'master'}}branded{{/unlessEquals}}</strong> components you need in a single request, by adding more modules to the link and/or script URLs like so:</p>
 
-		<pre class="overflow">https://www.ft.com/__origami/service/build/v2/bundles/css?modules={{@root.component.name}}@^{{@root.component.version}},module@version,module@version{{#unlessEquals requestedBrand 'master'}}?brand={{requestedBrand}}{{/unlessEquals}}</pre>
+		<pre class="overflow">https://www.ft.com/__origami/service/build/v2/bundles/css?modules={{@root.component.name}}@^{{@root.component.version}},module@version,module@version{{#unlessEquals requestedBrand 'master'}}&brand={{requestedBrand}}{{/unlessEquals}}</pre>
 
 		<p>For full build service options see the <a class="link" href="http://origami.ft.com/docs/developer-guide/build-service/#api-reference">build service API docs</a></p>
 	</script>

--- a/views/partials/header/nav.html
+++ b/views/partials/header/nav.html
@@ -12,7 +12,7 @@
 				</a>
 			</li>
 			<li class="o-header-services__nav-item">
-				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="/components">
+				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="/components{{#unlessEquals @root.component.requestedBrand 'master' }}?brand={{ @root.component.requestedBrand }}{{/unlessEquals}}">
 					Components
 				</a>
 			</li>

--- a/views/partials/overview/component-list.html
+++ b/views/partials/overview/component-list.html
@@ -14,7 +14,7 @@
 				data-o-component-support-status="{{support.status}}"
 				role="listitem">
 					<div class="registry__group-item">
-						<a class='registry__group-item--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
+						<a class='registry__group-item--link' href="/components/{{name}}@{{version}}{{#unlessEquals @root.requestedBrand 'master' }}?brand={{ @root.requestedBrand }}{{/unlessEquals}}" data-test="component-link">{{name}}</a>
 						<p class='registry__group-item--description'>{{description}}</p>
 					</div>
 					<div class="registry__group-stats">


### PR DESCRIPTION
Some quick improvements to break up the day. :D  

- Add current brand to component links. A cheap and cheerful way to "remember" what brand the user is interested in as they browse the registry. We could improve this e.g. to handle returning visits.
- Also correct build service link/script tag docs. 
`?o-footer@^6.0.10?brand=internal` 👉 `?o-footer@^6.0.10&brand=internal`

<img width="483" alt="screen shot 2018-07-09 at 16 11 48" src="https://user-images.githubusercontent.com/10405691/42459529-b7319fda-8393-11e8-8548-ba180e8f0781.png">
