### PR TITLE
Correct branding defaults

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -43,8 +43,7 @@ module.exports = app => {
 			response.render('overview', {
 				title: `Components - ${app.ft.options.name}`,
 				categories: repoListing.categorise(repos),
-				filter,
-				currentBrand: request.query.brand || 'master'
+				filter
 			});
 		} catch (error) {
 			next(error);

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -14,11 +14,11 @@ module.exports = app => {
 		staleWhileRevalidate: '7 days',
 		staleIfError: '7 days'
 	});
+
 	// Component listing page
 	app.get('/components', cacheForFiveMinutes, express.urlencoded({extended: false}), async (request, response, next) => {
 		try {
 			let repos = await app.repoData.listRepos();
-			const requestedBrand = (request.query.brand) ? request.query.brand : 'master';
 
 			// Default the filter
 			const filterIsPresent = (request.query.search !== undefined);
@@ -44,7 +44,7 @@ module.exports = app => {
 				title: `Components - ${app.ft.options.name}`,
 				categories: repoListing.categorise(repos),
 				filter,
-				requestedBrand
+				currentBrand: request.query.brand || 'master'
 			});
 		} catch (error) {
 			next(error);
@@ -54,9 +54,9 @@ module.exports = app => {
 	// Individual component page
 	app.get('/components/:componentId', cacheForFiveMinutes, async (request, response, next) => {
 		const [componentName, componentVersion] = request.params.componentId.split('@');
-		const requestedBrand = (request.query.brand) ? request.query.brand : 'master';
-
+		const requestedBrand = request.query.brand || null;
 		try {
+
 			// Get all versions of the component so we already have the listing
 			const versions = await app.repoData.listVersions(componentName);
 			let component;
@@ -86,6 +86,32 @@ module.exports = app => {
 				return response.redirect(307, `${request.basePath}components/${component.name}@${component.version}`);
 			}
 
+			// Set the current brand based on the query string,
+			// as long as the component is branded
+			let currentBrand = 'master';
+			if (component.brands && component.brands.length) {
+
+				// When a brand is set via the querystring
+				if (requestedBrand) {
+					if (component.brands.includes(requestedBrand)) {
+						currentBrand = requestedBrand;
+					} else {
+						throw httpError(404);
+					}
+
+				// Default brand
+				} else {
+					if (component.brands.includes('master')) {
+						currentBrand = 'master';
+					} else {
+						// If the component does not support masterbrand,
+						// we should default to the first brand it announces
+						// support for
+						currentBrand = component.brands[0];
+					}
+				}
+			}
+
 			// Load dependencies
 			let dependencies;
 			if (component.resources.dependencies) {
@@ -100,11 +126,6 @@ module.exports = app => {
 				};
 			}
 
-			//if a brand has been requested, set it to the component to pass on to the component page
-			if (requestedBrand) {
-				component.requestedBrand = requestedBrand;
-			}
-
 			// Load optional resources
 			let demos;
 			let images;
@@ -112,10 +133,10 @@ module.exports = app => {
 
 			// If the component is a module and it has demos, load them
 			if (component.type === 'module' && component.resources.demos) {
-				if (component.requestedBrand === 'master') {
+				if (currentBrand === 'master') {
 					demos = await app.repoData.listDemos(component.repo, component.id);
 				} else {
-					demos = await app.repoData.listDemos(component.repo, component.id, component.requestedBrand);
+					demos = await app.repoData.listDemos(component.repo, component.id, currentBrand);
 				}
 
 				// fetch the plain HTML and higlight it so we can style it
@@ -137,9 +158,6 @@ module.exports = app => {
 				service = await app.repoData.getManifest(component.repo, component.id, 'about');
 			}
 
-			// Augment the component object with a major version number, for use in image sets
-			component.majorVersion = component.version;
-
 			// Load and filter all repositories for use in the sidebar
 			const repos = (await app.repoData.listRepos()).filter(repo => {
 				return (
@@ -147,29 +165,35 @@ module.exports = app => {
 					repo.support.status === 'maintained'
 				);
 			});
+			const categories = repoListing.categorise(repos);
 
-			// Check if component is brand-able so that we can display a message
-			//(has css & js or only css, is a module and hasn't been branded)
+			// Check if component is brandable so that we can display a message
+			// (has css & js or only css, is a module and hasn't been branded)
 			if (component.brands && component.brands.length === 0 && component.type === 'module') {
 				if (component.hasCSS && component.hasJS || component.hasCSS) {
 					component.brandable = true;
 				}
 			}
 
+			// Check whether a component has brands/should display the brand tabs
+			component.hasBrands = (component.brands && component.brands.length);
+
 			// Render the component page
 			response.render('component', {
 				title: `${component.name} - ${app.ft.options.name}`,
-				categories: repoListing.categorise(repos),
+				categories,
 				component,
 				demos,
 				dependencies,
 				images,
 				service,
-				versions
+				versions,
+				currentBrand
 			});
 
 		} catch (error) {
 			if (error.status === 404) {
+				response.locals.requestedBrand = requestedBrand;
 				response.locals.missingComponentName = componentName;
 				response.locals.missingComponentVersion = componentVersion || 'latest';
 			}

--- a/views/error.html
+++ b/views/error.html
@@ -8,14 +8,20 @@
 		{{#if missingComponentName}}
 			<p>
 				The component that you're looking for was not found:<br/>
-				<span>{{missingComponentName}} @ {{missingComponentVersion}}</span>
+				<span>{{missingComponentName}} @ {{missingComponentVersion}}{{#if requestedBrand}} ("{{requestedBrand}}" brand){{/if}}</span>
 			</p>
 			{{#unlessEquals missingComponentVersion "latest"}}
 				<p>
-					Try requesting the <a class="link" href="/components/{{missingComponentName}}@latest">component without a version number</a>,
+					Try requesting the <a class="link" href="/components/{{missingComponentName}}@latest">component without a version number</a>,<br/>
 					to see whether it actually exists.
 				</p>
 			{{/unlessEquals}}
+			{{#if requestedBrand}}
+				<p>
+					The brand "{{requestedBrand}}" may not be implemented for this component,<br/>
+					try requesting the <a class="link" href="/components/{{missingComponentName}}@{{missingComponentVersion}}">component without a brand</a>.
+				</p>
+			{{/if}}
 			<p>
 				Try <a class="link" href="/components?search={{missingComponentName}}&module=true&imageset=true&service=true&active=true&maintained=true&deprecated=true&dead=true&experimental=true">searching for the component name on the registry home page</a>.
 			</p>

--- a/views/partials/component/brand-tabs.html
+++ b/views/partials/component/brand-tabs.html
@@ -1,8 +1,8 @@
 <div class="registry__component">
-	{{#unlessEquals component.brands.length 0}}
+	{{#if component.hasBrands}}
 		<div class="registry__brands">
 			{{#component.brands}}
-				<a class="registry__brands-button {{#ifEquals this @root.component.requestedBrand}}registry__brands-button--current{{/ifEquals}}"
+				<a class="registry__brands-button {{#ifEquals this @root.currentBrand}}registry__brands-button--current{{/ifEquals}}"
 				href="{{#ifEquals this 'master'}}{{@root.component.name}}{{else}}?brand={{this}}{{/ifEquals}}">{{this}} brand</a>
 			{{/component.brands}}
 		</div>
@@ -11,5 +11,5 @@
 
 	{{else}}
 		{{> component/container }}
-	{{/unlessEquals}}
+	{{/if}}
 </div>

--- a/views/partials/component/list-sidebar.html
+++ b/views/partials/component/list-sidebar.html
@@ -15,7 +15,7 @@
 					data-o-component-keywords="{{json keywords}}"
 					data-o-component-type="{{type}}"
 					data-o-component-sub-type="{{subType}}">
-					<a href="/components/{{name}}@{{version}}{{#unlessEquals @root.currentBrand 'master' }}?brand={{ @root.currentBrand }}{{/unlessEquals}}">{{name}}</a>
+					<a href="/components/{{name}}@{{version}}">{{name}}</a>
 				</li>
 			{{/repos}}
 		{{/if}}

--- a/views/partials/component/list-sidebar.html
+++ b/views/partials/component/list-sidebar.html
@@ -15,7 +15,7 @@
 					data-o-component-keywords="{{json keywords}}"
 					data-o-component-type="{{type}}"
 					data-o-component-sub-type="{{subType}}">
-					<a href="/components/{{name}}@{{version}}{{#unlessEquals @root.component.requestedBrand 'master' }}?brand={{ @root.component.requestedBrand }}{{/unlessEquals}}">{{name}}</a>
+					<a href="/components/{{name}}@{{version}}{{#unlessEquals @root.currentBrand 'master' }}?brand={{ @root.currentBrand }}{{/unlessEquals}}">{{name}}</a>
 				</li>
 			{{/repos}}
 		{{/if}}

--- a/views/partials/component/quickstart/build-service.html
+++ b/views/partials/component/quickstart/build-service.html
@@ -10,7 +10,7 @@
 				{{#if @root.component.hasCSS}}<code>&lt;link&gt;</code> tag{{/if}}
 			{{/ifBoth}}
 		</p>
-		<pre  class="overflow">{{@root.component.name}}@^{{@root.component.version}}{{#unlessEquals requestedBrand 'master'}}&brand={{requestedBrand}}{{/unlessEquals}}</pre>
+		<pre  class="overflow">{{@root.component.name}}@^{{@root.component.version}}{{#unlessEquals @root.currentBrand 'master'}}&brand={{@root.currentBrand}}{{/unlessEquals}}</pre>
 		<p><a class="o-overlay-trigger link"
 					data-o-overlay-id="overlay"
 					data-o-overlay-src="#how-do-i-build-service"
@@ -38,11 +38,11 @@
 			to your page:
 		</p>
 
-		<pre class="overflow">&lt;link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules={{@root.component.name}}@^{{@root.component.version}}{{#if requestedBrand}}&brand={{requestedBrand}}{{/if}}" /><br>&lt;script src="https://www.ft.com/__origami/service/build/v2/bundles/js?modules={{@root.component.name}}@^{{@root.component.version}}">&lt;/script></pre>
+		<pre class="overflow">&lt;link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules={{@root.component.name}}@^{{@root.component.version}}{{#unlessEquals @root.currentBrand 'master'}}&brand={{@root.currentBrand}}{{/unlessEquals}}" /><br>&lt;script src="https://www.ft.com/__origami/service/build/v2/bundles/js?modules={{@root.component.name}}@^{{@root.component.version}}">&lt;/script></pre>
 
-		<p>You should have <strong>only one</strong> (Origami related) <code>&lt;script&gt;</code> and one <code>&lt;link&gt;</code> tag in your page, even if you want to load more than one component. <br>You can request all <strong>{{#unlessEquals requestedBrand 'master'}}branded{{/unlessEquals}}</strong> components you need in a single request, by adding more modules to the link and/or script URLs like so:</p>
+		<p>You should have <strong>only one</strong> (Origami related) <code>&lt;script&gt;</code> and one <code>&lt;link&gt;</code> tag in your page, even if you want to load more than one component. <br>You can request all <strong>{{#unlessEquals @root.currentBrand 'master'}}branded{{/unlessEquals}}</strong> components you need in a single request, by adding more modules to the link and/or script URLs like so:</p>
 
-		<pre class="overflow">https://www.ft.com/__origami/service/build/v2/bundles/css?modules={{@root.component.name}}@^{{@root.component.version}},module@version,module@version{{#unlessEquals requestedBrand 'master'}}&brand={{requestedBrand}}{{/unlessEquals}}</pre>
+		<pre class="overflow">https://www.ft.com/__origami/service/build/v2/bundles/css?modules={{@root.component.name}}@^{{@root.component.version}},module@version,module@version{{#unlessEquals @root.currentBrand 'master'}}&brand={{@root.currentBrand}}{{/unlessEquals}}</pre>
 
 		<p>For full build service options see the <a class="link" href="http://origami.ft.com/docs/developer-guide/build-service/#api-reference">build service API docs</a></p>
 	</script>

--- a/views/partials/header/nav.html
+++ b/views/partials/header/nav.html
@@ -12,7 +12,7 @@
 				</a>
 			</li>
 			<li class="o-header-services__nav-item">
-				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="/components{{#unlessEquals @root.currentBrand 'master' }}?brand={{ @root.currentBrand }}{{/unlessEquals}}">
+				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="/components">
 					Components
 				</a>
 			</li>

--- a/views/partials/header/nav.html
+++ b/views/partials/header/nav.html
@@ -12,7 +12,7 @@
 				</a>
 			</li>
 			<li class="o-header-services__nav-item">
-				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="/components{{#unlessEquals @root.component.requestedBrand 'master' }}?brand={{ @root.component.requestedBrand }}{{/unlessEquals}}">
+				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="/components{{#unlessEquals @root.currentBrand 'master' }}?brand={{ @root.currentBrand }}{{/unlessEquals}}">
 					Components
 				</a>
 			</li>

--- a/views/partials/overview/component-list.html
+++ b/views/partials/overview/component-list.html
@@ -14,7 +14,7 @@
 				data-o-component-support-status="{{support.status}}"
 				role="listitem">
 					<div class="registry__group-item">
-						<a class='registry__group-item--link' href="/components/{{name}}@{{version}}{{#unlessEquals @root.currentBrand 'master' }}?brand={{ @root.currentBrand }}{{/unlessEquals}}" data-test="component-link">{{name}}</a>
+						<a class='registry__group-item--link' href="/components/{{name}}@{{version}}" data-test="component-link">{{name}}</a>
 						<p class='registry__group-item--description'>{{description}}</p>
 					</div>
 					<div class="registry__group-stats">

--- a/views/partials/overview/component-list.html
+++ b/views/partials/overview/component-list.html
@@ -14,7 +14,7 @@
 				data-o-component-support-status="{{support.status}}"
 				role="listitem">
 					<div class="registry__group-item">
-						<a class='registry__group-item--link' href="/components/{{name}}@{{version}}{{#unlessEquals @root.requestedBrand 'master' }}?brand={{ @root.requestedBrand }}{{/unlessEquals}}" data-test="component-link">{{name}}</a>
+						<a class='registry__group-item--link' href="/components/{{name}}@{{version}}{{#unlessEquals @root.currentBrand 'master' }}?brand={{ @root.currentBrand }}{{/unlessEquals}}" data-test="component-link">{{name}}</a>
 						<p class='registry__group-item--description'>{{description}}</p>
 					</div>
 					<div class="registry__group-stats">


### PR DESCRIPTION
Ensure that components which don't have masterbrand styles default to
the correct brand. The way we do it now:

  - If a brand is specified in the querystring, use that brand
  - If no brand is specified and the component supports masterbrand,
    default to masterbrand
  - If no brand is specified and the component does not support
  	masterbrand, default to the first supported brand

Also we now only apply the branding parameters when you explicitly click
on one of the brand tabs on a component page.