### PR TITLE
Add app.json for heroku apps to be created automatically on pull-requests

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,47 @@
+{
+  "name": "origami-registry-ui",
+  "scripts": {},
+  "env": {
+    "CMDB_API_KEY": {
+      "required": true
+    },
+    "GITHUB_RELEASE_TOKEN": {
+      "required": true
+    },
+    "GITHUB_RELEASE_USER": {
+      "required": true
+    },
+    "GRAPHITE_API_KEY": {
+      "required": true
+    },
+    "REGION": {
+      "required": true
+    },
+    "RELEASE_LOG_API_KEY": {
+      "required": true
+    },
+    "RELEASE_LOG_ENVIRONMENT": {
+      "required": true
+    },
+    "REPO_DATA_API_KEY": {
+      "required": true
+    },
+    "REPO_DATA_API_SECRET": {
+      "required": true
+    },
+    "SENTRY_DSN": {
+      "required": true
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}


### PR DESCRIPTION
By having this file, we can enable review applications to be created against pull-requests, if we want to have them. I think it will make reviewing changes simpler for the team