### PR TITLE
Misc minor fixes

### DIFF
--- a/lib/code-docs/sassdoc/nodes/base.js
+++ b/lib/code-docs/sassdoc/nodes/base.js
@@ -5,13 +5,15 @@ const Example = require('../../example');
 class BaseNode {
     constructor(doclet) {
         const groupKey = Array.isArray(doclet.group) ? doclet.group[0] : undefined;
+        const fileName = doclet.file && doclet.file.name ? doclet.file.name : '';
+        const filePath = doclet.file && doclet.file.path ? doclet.file.path : '';
         const docletContext = doclet.context || {};
         this.name = docletContext.name || '';
         this.description = doclet.description || '';
         this.longname = [groupKey, docletContext.type, docletContext.name].filter(part => part && part !== 'undefined').join('-');
         this.file = {
-            path: doclet.file && doclet.file.path ? doclet.file.path : '',
-            name: doclet.file && doclet.file.name ? doclet.file.name : ''
+            path: filePath.replace(new RegExp(`${fileName}$`), ''),
+            name: fileName
         };
         if (doclet.context && doclet.context.line && doclet.context.line.start) {
             this.file.lineno = doclet.context.line.start;

--- a/test/unit/lib/code-docs/sassdoc/nodes/base.test.js
+++ b/test/unit/lib/code-docs/sassdoc/nodes/base.test.js
@@ -107,7 +107,7 @@ describe('lib/code-docs/sassdoc/nodes/base', () => {
         assert.equal(node.description, '', 'Did not add expected description property.');
         assert.equal(node.longname, 'helpers-function-oTestComponentDouble', 'Did not add expected longname property.');
         assert.deepEqual(node.file, {
-            'path': 'src/scss/_functions.scss',
+            'path': 'src/scss/',
             'name': '_functions.scss',
             'lineno': 24
         }, 'Did not add expected file property.');
@@ -139,7 +139,7 @@ describe('lib/code-docs/sassdoc/nodes/base', () => {
         assert.equal(node.description, '', 'Did not add expected description property.');
         assert.equal(node.longname, 'function-oTestComponentDouble', 'Did not add expected longname property.');
         assert.deepEqual(node.file, {
-            'path': 'src/scss/_functions.scss',
+            'path': 'src/scss/',
             'name': '_functions.scss',
             'lineno': 24
         }, 'Did not add expected file property.');

--- a/views/partials/overview/sidebar.html
+++ b/views/partials/overview/sidebar.html
@@ -1,33 +1,33 @@
 <div class="registry__container__sticky">
 
-		<h2>Library Updates</h2>
-		<p>The registry is updated whenever a new tag is pushed to a repository that has an <code>origami.json</code> file in it. If your repository meets the following criteria then it should be ingested within 5 minutes:</p>
+	<h2>Library Updates</h2>
+	<p>The registry is updated whenever a new tag is pushed to a repository that has an <code>origami.json</code> file in it. If your repository meets the following criteria then it should be ingested within 5 minutes:</p>
 
-		<ul>
-			<li>
-				It lives in the
-				<a class="link" href="https://github.com/Financial-Times">Financial-Times GitHub organisation</a>
-			</li>
-			<li>
-				It contains a valid <code>origami.json</code> file
-				(see <a class="link" href="http://origami.ft.com/docs/syntax/origamijson/">the spec</a> for more information)
-			</li>
-			<li>
-				It has at least one git tag which complies with
-				<a class="link" href="https://semver.org/">semantic versioning</a>
-			</li>
-		</ul>
+	<ul>
+		<li>
+			It lives in the
+			<a class="link" href="https://github.com/Financial-Times">Financial-Times GitHub organisation</a>
+		</li>
+		<li>
+			It contains a valid <code>origami.json</code> file
+			(see <a class="link" href="http://origami.ft.com/docs/syntax/origamijson/">the spec</a> for more information)
+		</li>
+		<li>
+			It has at least one git tag which complies with
+			<a class="link" href="https://semver.org/">semantic versioning</a>
+		</li>
+	</ul>
 
-		<h2>Bower Registry</h2>
+	<h2>Bower Registry</h2>
 
-		<p>The Origami components library provides a read-only API conforming to the Bower Registry API spec (excluding registration and publishing).  To specify the Origami components library as your source for Bower components, create a <code>.bowerrc</code> file in your home directory or the root of your project's working tree, with the following content:</p>
+	<p>The Origami components library provides a read-only API conforming to the Bower Registry API spec (excluding registration and publishing).  To specify the Origami components library as your source for Bower components, create a <code>.bowerrc</code> file in your home directory or the root of your project's working tree, with the following content:</p>
 
-		<pre class="overflow"><code>{
-			"registry": {
-				"search": [
-					"https://origami-bower-registry.ft.com",
-					"https://registry.bower.io"
-				]
-			}
-		}</code></pre>
+	<pre class="overflow"><code>{
+	  "registry": {
+	    "search": [
+	      "https://origami-bower-registry.ft.com",
+	      "https://registry.bower.io"
+	    ]
+	  }
+	}</code></pre>
 </div>


### PR DESCRIPTION
Fixes sassdoc links to Github by removing the filename from sassdoc path (Jsdoc provides a path and filename seperately, making sassdoc do the same allows for shared templates.).
<img width="376" alt="screen shot 2018-10-16 at 10 54 51" src="https://user-images.githubusercontent.com/10405691/47008283-ed525a00-d131-11e8-83b8-7ed9f23ba80d.png">

Fixes indentation of code in sidebar: 
<img width="361" alt="screen shot 2018-10-16 at 10 52 19" src="https://user-images.githubusercontent.com/10405691/47008133-a49aa100-d131-11e8-8416-9bf16745be3a.png">
