### PR TITLE
JSDoc non-module components. Typography.

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -89,8 +89,8 @@ module.exports = app => {
 			if (component.languages) {
 				component.hasCSS = (component.languages.includes('css') || component.languages.includes('scss') || component.languages.includes('sass'));
 				component.hasJS = component.languages.includes('js');
-				component.showJSDoc = component.hasJS && component.type === 'module';
-				component.showSassDoc = component.hasCSS && component.type === 'module';
+				component.showJSDoc = component.hasJS && (component.type === 'module' || component.type === null);
+				component.showSassDoc = component.hasCSS && (component.type === 'module' || component.type === null);
 			};
 
 			request.component = component;

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -89,6 +89,8 @@ module.exports = app => {
 			if (component.languages) {
 				component.hasCSS = (component.languages.includes('css') || component.languages.includes('scss') || component.languages.includes('sass'));
 				component.hasJS = component.languages.includes('js');
+				component.showJSDoc = component.hasJS && component.type === 'module';
+				component.showSassDoc = component.hasCSS && component.type === 'module';
 			};
 
 			request.component = component;

--- a/src/scss/component/_codedocs.scss
+++ b/src/scss/component/_codedocs.scss
@@ -1,5 +1,11 @@
 .registry__doclet {
     display: none;
+    h1 {
+		@include oTypographyProductHeadingLevel1();
+    }
+    h2 {
+		@include oTypographyProductHeadingLevel5();
+    }
 }
 
 .registry__doclet--default,

--- a/src/scss/component/_readme.scss
+++ b/src/scss/component/_readme.scss
@@ -1,0 +1,20 @@
+.registry__readme {
+    // Heading levels are not mapped directly for clearer visual hierarchy.
+    // Product level headings updates upcoming.
+    // https://github.com/Financial-Times/o-typography/issues/159
+	h1 {
+		@include oTypographyProductHeadingLevel1();
+    }
+	h2 {
+		@include oTypographyProductHeadingLevel2();
+    }
+	h3 {
+		@include oTypographyProductHeadingLevel5();
+    }
+	h4 {
+		@include oTypographyProductHeadingLevel7();
+    }
+	h5 {
+		@include oTypographyProductHeadingLevel8();
+    }
+}

--- a/src/scss/component/main.scss
+++ b/src/scss/component/main.scss
@@ -1,4 +1,5 @@
 @import 'demos';
+@import 'readme';
 @import 'brand-tabs';
 @import 'dependencies';
 @import 'header';

--- a/views/partials/codedocs/sassdoc/sassdoc-node.html
+++ b/views/partials/codedocs/sassdoc/sassdoc-node.html
@@ -3,7 +3,7 @@
     class="registry__doclet {{#if default}}registry__doclet--default{{/if}}">
     {{> codedocs/nodes/sections/deprecation-warning }}
 
-    <h1 class="registry__component-name">
+    <h1>
         {{> codedocs/nodes/sections/name }}
     </h1>
 

--- a/views/partials/header/nav.html
+++ b/views/partials/header/nav.html
@@ -45,14 +45,14 @@
 								Readme
 							</a>
 						</li>
-						{{#if component.hasCSS}}
+						{{#if component.showSassDoc}}
 							<li class="o-header__subnav-item">
 								<a class="o-header__subnav-link" href="/components/{{ component.name }}@{{ component.version }}/sassdoc" {{#ifEquals nav 'sassdoc'}}aria-selected="true"{{/ifEquals}}>
 									SassDoc
 								</a>
 							</li>
 						{{/if}}
-						{{#if component.hasJS}}
+						{{#if component.showJSDoc}}
 							<li class="o-header__subnav-item">
 								<a class="o-header__subnav-link" href="/components/{{ component.name }}@{{ component.version }}/jsdoc" {{#ifEquals nav 'jsdoc'}}aria-selected="true"{{/ifEquals}} >
 									JsDoc


### PR DESCRIPTION
**Only show jsdoc for components of type module, or undefined types**

Show JSDoc for components that are modules or not defined (i.e. not imageset, not service). The codedocs api currently only supports module types with a `main.js` and `/src` directories, but will soon include the `/lib` directory to support our "components" which are neither services, or imagesets -- i.e. clients such as `origami-repo-data-client-node`.

Depends on: https://github.com/Financial-Times/origami-codedocs/pull/5

<img width="1394" alt="screen shot 2018-10-17 at 17 46 39" src="https://user-images.githubusercontent.com/10405691/47102705-51aa1200-d235-11e8-9e88-6b955ca0ac88.png">

**Also I couldn't resist including typography changes:**

Product headings are intended for interal products but offer poor visual hierarchy, hence mixins for heading levels are not used literally. We have an issue for this: https://github.com/Financial-Times/o-typography/issues/159 

Before:
<img width="1372" alt="screen shot 2018-10-17 at 16 43 19" src="https://user-images.githubusercontent.com/10405691/47098935-1fe07d80-d22c-11e8-92f3-9b1688a40309.png">

After:
<img width="1372" alt="screen shot 2018-10-17 at 16 43 16" src="https://user-images.githubusercontent.com/10405691/47098950-28d14f00-d22c-11e8-8b85-e5822cc6452f.png">

Before:
<img width="1050" alt="screen shot 2018-10-17 at 16 45 35" src="https://user-images.githubusercontent.com/10405691/47098958-325ab700-d22c-11e8-982c-d9c88b236227.png">

After:
<img width="1050" alt="screen shot 2018-10-17 at 16 45 38" src="https://user-images.githubusercontent.com/10405691/47098969-3a1a5b80-d22c-11e8-9447-438e9258b2aa.png">
