### PR TITLE
Add a canonical link to component pages.

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -95,7 +95,13 @@ module.exports = app => {
 				component.showSassDoc = component.hasCSS && (component.type === 'module' || component.type === null);
 			};
 
+			// Add canonical URl for the component (i.e. url for the latest version).
+			component.canonicalUrl = request.url
+				.replace(`/components/${component.name}@${component.version}`, `/components/${component.name}`)
+				.replace(/\/$/g, ''); // remove trailing slash
+
 			request.component = component;
+
 			next();
 		} catch (error) {
 			if (error.status === 404) {
@@ -242,6 +248,7 @@ module.exports = app => {
 			// Render the component page
 			response.render('component', {
 				title: `${component.name} - ${app.ft.options.name}`,
+				canonical: component.canonicalUrl,
 				component,
 				demos,
 				dependencies,
@@ -296,6 +303,7 @@ module.exports = app => {
 		try {
 			response.render('jsdoc', {
 				title: `${component.name} JSDoc - ${app.ft.options.name}`,
+				canonical: component.canonicalUrl,
 				component,
 				versions,
 				currentBrand,
@@ -343,6 +351,7 @@ module.exports = app => {
 		try {
 			response.render('sassdoc', {
 				title: `${component.name} SassDoc - ${app.ft.options.name}`,
+				canonical: component.canonicalUrl,
 				component,
 				versions,
 				currentBrand,
@@ -369,6 +378,7 @@ module.exports = app => {
 
 			response.render('readme', {
 				title: `${component.name} README - ${app.ft.options.name}`,
+				canonical: component.canonicalUrl,
 				component,
 				versions,
 				currentBrand,

--- a/test/integration/routes/components-(id)-readme.test.js
+++ b/test/integration/routes/components-(id)-readme.test.js
@@ -29,6 +29,11 @@ describe('GET /components/:componentId/readme', () => {
                 dom = new JSDOM((await request.then()).text);
             });
 
+            it('includes a canonical url for the latest component version', () => {
+                const html = dom.window.document.documentElement.outerHTML;
+                assert.include(html, '<link rel="canonical" href="/components/o-example-active/readme">');
+            });
+
             it('includes the component\'s readme', () => {
                 const readmeContent = dom.window.document.querySelector('#test-readme');
                 assert.isNotNull(readmeContent);

--- a/test/integration/routes/components-(id).test.js
+++ b/test/integration/routes/components-(id).test.js
@@ -47,6 +47,11 @@ describe('GET /components/:componentId', () => {
 				assert.strictEqual(supportStatus.textContent.trim(), 'active');
 			});
 
+			it('includes a canonical url for the latest component version', () => {
+				const html = dom.window.document.documentElement.outerHTML;
+				assert.include(html, '<link rel="canonical" href="/components/o-example-active">');
+			});
+
 		});
 
 	});

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -6,6 +6,10 @@
 	<title>{{title}}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+	{{#if canonical}}
+		<link rel="canonical" href="{{canonical}}" />
+	{{/if}}
+
 	<link rel="icon" type="image/png" href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Aorigami?source=origami-registry-ui&width=16&height=16&format=png" sizes="16x16">
 	<link rel="icon" type="image/png" href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Aorigami?source=origami-registry-ui&width=32&height=32&format=png" sizes="32x32">
 	<link rel="icon" type="image/png" href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Aorigami?source=origami-registry-ui&width=96&height=96&format=png" sizes="96x96">
@@ -13,6 +17,7 @@
 	<link rel="icon" type="image/png" href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Aorigami?source=origami-registry-ui&width=196&height=196&format=png" sizes="196x196">
 	<link rel="icon" type="image/png" href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Aorigami?source=origami-registry-ui&width=310&height=310&format=png" sizes="310x310">
 	<link rel="icon" type="image/svg+xml" href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Aorigami?source=origami-registry-ui&format=svg" sizes="any">
+
 
 	{{> ctm }}
 


### PR DESCRIPTION
Add a canonical link to component pages, so the latest component version is displayed in Google.

<img width="681" alt="screen shot 2018-11-21 at 14 54 51" src="https://user-images.githubusercontent.com/10405691/48849043-6c742700-ed9d-11e8-9734-55a43979e8a8.png">
