### PR TITLE
Update showdown and escape HTML when outputting markdown in templates.

### DIFF
--- a/lib/code-docs/readme/index.js
+++ b/lib/code-docs/readme/index.js
@@ -10,11 +10,6 @@ class ReadMe {
     constructor(markdown, currentHost = undefined) {
         const converter = new showdown.Converter({ simplifiedAutoLink: true });
         converter.setFlavor('github');
-        // Workaround for https://github.com/showdownjs/showdown/pull/569
-        // Remove space between start of code block and language declaration.
-        markdown = markdown.replace(/(?:^|\n)(```+|~~~+)( +)([^\s`~]*)\n/g, function (wholeMatch, delim, spaces, language) {
-            return `\n${delim}${language}\n`;
-        });
         this.html = converter.makeHtml(markdown);
         this.markdown = markdown;
         this.removeNav();

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -58,6 +58,7 @@ function json(value) {
 function markdown(value, headerLevelStart = 1) {
     const converter = new showdown.Converter({
 		headerLevelStart,
+		backslashEscapesHTMLTags: true,
 		simplifiedAutoLink: true
 	});
 	return converter.makeHtml(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7657,9 +7657,9 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "showdown": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
-      "integrity": "sha1-kepO47elRIqspoIKTifmkMatdxw=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.0.tgz",
+      "integrity": "sha512-x7xDCRIaOlicbC57nMhGfKamu+ghwsdVkHMttyn+DelwzuHOx4OHCVL/UW/2QOLH7BxfCcCCVVUix3boKXJKXQ==",
       "requires": {
         "yargs": "^10.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "request-promise-native": "^1.0.5",
     "require-all": "^2.2.0",
     "sassdoc-extras": "^2.4.3",
-    "showdown": "^1.8.6",
+    "showdown": "^1.9.0",
     "throng": "^4.0.0"
   },
   "devDependencies": {

--- a/test/unit/lib/helpers/index.test.js
+++ b/test/unit/lib/helpers/index.test.js
@@ -24,6 +24,24 @@ describe('helpers', () => {
 		assert.strictEqual(helper.json(string), '{"string":"lowercase"}');
 	});
 
+	describe('.markdown', () => {
+		it('converts markdown to html', () => {
+			const string = 'some copy';
+			assert.strictEqual(helper.markdown(string), '<p>some copy</p>');
+		});
+
+		it('supports "header level start"', () => {
+			const string = '#my-h1\n##my-h2';
+			const headerLevelStart = 3;
+			assert.strictEqual(helper.markdown(string, headerLevelStart), '<h3 id="myh1">my-h1</h3>\n<h4 id="myh2">my-h2</h4>');
+		});
+
+		it('escapes HTML so code comments cannot break registry ui"', () => {
+			const string = 'Base tables styles - add to <table>';
+			assert.strictEqual(helper.markdown(string), '<p>Base tables styles - add to \<table\></p>');
+		});
+	});
+
 	describe('conditional helpers', () => {
 		let args = [];
 		const opts = {


### PR DESCRIPTION
Escape HTML when outputting markdown in templates. This old `o-table` comment is [currently breaking the UI of registry-ui](http://localhost:8080/components/o-table@6.9.2/sassdoc):

<img width="395" alt="screenshot 2018-11-30 at 16 29 37" src="https://user-images.githubusercontent.com/10405691/49302515-3cc0cf80-f4bf-11e8-869f-2311313b1268.png">

Also updates to the latest version of showdown.