### PR TITLE
Do not error when there are no demos for a given brand.

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -187,7 +187,13 @@ module.exports = app => {
 
 			// If the component is a module and it has demos, load them
 			if (component.type === 'module' && component.resources.demos) {
-				demos = await app.repoData.listDemos(component.repo, component.id, currentBrand);
+				try {
+					demos = await app.repoData.listDemos(component.repo, component.id, currentBrand);
+				} catch (error) {
+					if (error.status !== 404) {
+						throw error;
+					}
+				}
 
 				// fetch the plain HTML and higlight it so we can style it
 				try {

--- a/test/integration/mock/repo-data-api/data/repos.js
+++ b/test/integration/mock/repo-data-api/data/repos.js
@@ -99,7 +99,7 @@ module.exports = [
 		_versions: ['1.2.3', '1.2.2', '1.2.1', '1.2.0', '1.1.0', '1.0.0']
 	},
 
-	// Active Origami component with no demos but no whitelabel brand demo
+	// Active Origami component with demos, but no demos for the whitelabel brand
 	{
 		name: 'o-example-demos-except-whitelabel',
 		type: null,

--- a/test/integration/mock/repo-data-api/data/repos.js
+++ b/test/integration/mock/repo-data-api/data/repos.js
@@ -97,6 +97,39 @@ module.exports = [
 
 		// mock use only
 		_versions: ['1.2.3', '1.2.2', '1.2.1', '1.2.0', '1.1.0', '1.0.0']
+	},
+
+	// Active Origami component with no demos but no whitelabel brand demo
+	{
+		name: 'o-example-demos-except-whitelabel',
+		type: null,
+		subType: null,
+		version: '1.5.0',
+		support: {
+			status: 'maintained',
+			email: 'origami@example.com',
+			channel: {
+				name: '#example-channel',
+				url: 'mock-channel-url'
+			},
+			isOrigami: true
+		},
+		resources: {
+			demos: [
+				{
+					'name': 'example',
+					'title': 'example',
+					'description': 'example',
+					'brands': [
+						'master',
+						'internal'
+					]
+				}
+			]
+		},
+
+		// mock use only
+		_versions: ['1.5.0', '1.4.0', '1.3.0', '1.2.0', '1.1.0', '1.0.0']
 	}
 
 ];

--- a/test/integration/routes/components-(id).test.js
+++ b/test/integration/routes/components-(id).test.js
@@ -162,4 +162,33 @@ describe('GET /components/:componentId', () => {
 
 	});
 
+	describe.only('when the named component has no demos for the brand', () => {
+
+		beforeEach(async () => {
+			request = agent.get('/components/o-example-demos-except-whitelabel@1.5.0?brand=whitelabel');
+		});
+
+		it('responds with a 200 status', () => {
+			return request.expect(200);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+		describe('HTML response', () => {
+			let html;
+
+			beforeEach(async () => {
+				html = (await request.then()).text;
+			});
+
+			it('contains the component Github link', () => {
+				assert.include(html, 'https://github.com/Financial-Times/o-fonts');
+			});
+
+		});
+
+	});
+
 });

--- a/test/integration/routes/components-(id).test.js
+++ b/test/integration/routes/components-(id).test.js
@@ -183,8 +183,8 @@ describe('GET /components/:componentId', () => {
 				html = (await request.then()).text;
 			});
 
-			it('contains the component Github link', () => {
-				assert.include(html, 'https://github.com/Financial-Times/o-fonts');
+			it('contains the component status', () => {
+				assert.include(html, 'data-test="support-status"');
 			});
 
 		});

--- a/test/integration/routes/components-(id).test.js
+++ b/test/integration/routes/components-(id).test.js
@@ -162,7 +162,7 @@ describe('GET /components/:componentId', () => {
 
 	});
 
-	describe.only('when the named component has no demos for the brand', () => {
+	describe('when the named component has no demos for the brand', () => {
 
 		beforeEach(async () => {
 			request = agent.get('/components/o-example-demos-except-whitelabel@1.5.0?brand=whitelabel');

--- a/test/integration/routes/components.test.js
+++ b/test/integration/routes/components.test.js
@@ -33,7 +33,7 @@ describe('GET /components', () => {
 			assert.isNotNull(list);
 
 			const listItems = list.querySelectorAll('[data-test=component-list-item]');
-			assert.lengthEquals(listItems, 4);
+			assert.lengthEquals(listItems, 5);
 
 			let link;
 


### PR DESCRIPTION
When a component has demos, but none of those demos are for the given brand, a 404 error is thrown. Instead show the component page with no demos.
E.g. https://registry.origami.ft.com/components/o-fonts@3.2.1?brand=whitelabel

From this:
<img width="1552" alt="screenshot 2019-01-25 at 15 10 24" src="https://user-images.githubusercontent.com/10405691/51754110-5e02fe00-20b3-11e9-94fb-e032f2ea52be.png">

Like this:
<img width="1552" alt="screenshot 2019-01-25 at 15 08 29" src="https://user-images.githubusercontent.com/10405691/51754067-47f53d80-20b3-11e9-92e3-c2ea94021526.png">
