### PR TITLE
Correct codedocs deprecation alert styles.

### DIFF
--- a/src/scss/component/_demos.scss
+++ b/src/scss/component/_demos.scss
@@ -83,8 +83,6 @@
 	border-bottom: 1px solid oColorsGetPaletteColor('slate-white-15');
 }
 
-p.o-layout__unstyled-element {
-	span {
-		@include oTypographyBold('sans');
-	}
+.service-details__title {
+	@include oTypographyBold('sans');
 }

--- a/views/partials/codedocs/nodes/sections/deprecation-warning.html
+++ b/views/partials/codedocs/nodes/sections/deprecation-warning.html
@@ -1,13 +1,14 @@
 {{#if deprecated }}
-<div class="registry__alert">
-    <div class="o-message o-message--notice o-message--inner o-message--warning" data-o-component="o-message" data-close="false">
-        <div class="o-message__container">
-            <div class="o-message__content">
+<div class="o-message o-message--notice o-message--inner o-message--warning-light" data-o-component="o-message" data-close="false">
+    <div class="o-message__container">
+        <div class="o-message__content">
+            <p class="o-layout__unstyled-element o-message__content-main">
                 <span class="o-message__content-highlight">The {{ kind }} "{{ name }}" is deprecated.</span>
-                <div class="o-message__content-additional">
-                    {{{ markdown deprecated }}} {{#unless deprecated }} Please contact the Origami team with any questions. {{/unless}}
-                </div>
-            </div>
+                <span class="o-message__content-detail">
+                    {{{ deprecated }}}
+                    {{#unless deprecated }} Please contact the Origami team with any questions. {{/unless}}
+                </span>
+            </p>
         </div>
     </div>
 </div>

--- a/views/partials/component/type/service.html
+++ b/views/partials/component/type/service.html
@@ -15,7 +15,7 @@
 
 {{#if service.primaryUrl}}
 	<li>
-		<span class="service-details__title">URL</span>: <a class="link" href="{{service.primaryUrl}}">{{service.primaryUrl}}</a>
+		<span class="service-details__title"><abbr title="Uniform Resource Locator">URL</abbr></span>: <a class="link" href="{{service.primaryUrl}}">{{service.primaryUrl}}</a>
 	</li>
 {{/if}}
 

--- a/views/partials/component/type/service.html
+++ b/views/partials/component/type/service.html
@@ -1,22 +1,25 @@
 <h3>Service Details</h3>
 
+<ul class="service-details">
 {{#if service.systemCode}}
-	<p class="o-layout__unstyled-element">
-		<span>System Code</span> — {{service.systemCode}}
-	</p>
+	<li>
+		<span class="service-details__title">System Code</span>: {{service.systemCode}}
+	</li>
 {{/if}}
 
 {{#if service.serviceTier}}
-	<p class="o-layout__unstyled-element">
-		<span>Service Tier</span> — {{service.serviceTier}}
-	</p>
+	<li>
+		<span class="service-details__title">Service Tier</span>: {{service.serviceTier}}
+	</li>
 {{/if}}
 
 {{#if service.primaryUrl}}
-	<p class="o-layout__unstyled-element">
-		<span>Url</span> — <a class="link" href="{{service.primaryUrl}}">{{service.primaryUrl}}</a>
-	</p>
+	<li>
+		<span class="service-details__title">URL</span>: <a class="link" href="{{service.primaryUrl}}">{{service.primaryUrl}}</a>
+	</li>
 {{/if}}
+
+</ul>
 
 {{#if service.links}}
 	<h3>Service Links</h3>


### PR DESCRIPTION
Also updates the service detail style, as the original selector incorrectly matched the deprecation alert.

Before:
<img width="635" alt="screenshot 2019-03-04 at 09 46 09" src="https://user-images.githubusercontent.com/10405691/53726264-87a70600-3e65-11e9-8a2d-be93531c11c0.png">
After:
<img width="630" alt="screenshot 2019-03-04 at 10 02 14" src="https://user-images.githubusercontent.com/10405691/53726265-883f9c80-3e65-11e9-9c03-16d070bc6999.png">

The service detail style has also been updated:
<img width="541" alt="screenshot 2019-03-04 at 10 06 59" src="https://user-images.githubusercontent.com/10405691/53726280-8e357d80-3e65-11e9-99cd-b6e63e2a338a.png">
