### PR TITLE
Add browser features to component's detail page.

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -280,9 +280,9 @@ module.exports = app => {
 				};
 			}
 
-			const origamiManifest = await app.repoData.getManifest(component.repo, component.id, 'origami');
 			let browserFeatures;
-			if(origamiManifest && origamiManifest.browserFeatures) {
+			const origamiManifest = await app.repoData.getManifest(component.repo, component.id, 'origami');
+			if (origamiManifest && origamiManifest.browserFeatures) {
 				browserFeatures = origamiManifest.browserFeatures;
 			}
 

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -280,6 +280,12 @@ module.exports = app => {
 				};
 			}
 
+			const origamiManifest = await app.repoData.getManifest(component.repo, component.id, 'origami');
+			let browserFeatures;
+			if(origamiManifest && origamiManifest.browserFeatures) {
+				browserFeatures = origamiManifest.browserFeatures;
+			}
+
 			// Render the details page
 			response.render('details', {
 				title: `${component.name} - ${app.ft.options.name}`,
@@ -288,6 +294,7 @@ module.exports = app => {
 				dependencies,
 				versions,
 				currentBrand,
+				browserFeatures,
 				nav: 'details',
 				heading: 'Details'
 			});

--- a/test/integration/mock/repo-data-api/data/repos.js
+++ b/test/integration/mock/repo-data-api/data/repos.js
@@ -30,6 +30,18 @@ module.exports = [
 				}
 			]
 		},
+		manifests: {
+			'origami': {
+				'browserFeatures': {
+					'required': [
+						'DOMTokenList'
+					],
+					'optional': [
+						'IntersectionObserver'
+					]
+				}
+			}
+		},
 		markdown: {
 			readme: '# o-example-active\n## test-readme\nExample content.'
 		},

--- a/test/integration/mock/repo-data-api/mock-service.js
+++ b/test/integration/mock/repo-data-api/mock-service.js
@@ -42,6 +42,16 @@ module.exports = async function mockRepoDataApi() {
 		}
 		response.send(repo.resources.dependencies);
 	});
+	api.get('/v1/repos/:name/versions/:versionId/manifests/:manifestType', (request, response, next) => {
+		const repo = repos.find(repo => repo.name === request.params.name);
+		if (!repo) {
+			return next(httpError(404));
+		}
+		if (!repo || !repo.manifests || !repo.manifests[request.params.manifestType]) {
+			return response.send({});
+		}
+		response.send(repo.manifests[request.params.manifestType]);
+	});
 	api.use((error, request, response, next) => { // eslint-disable-line no-unused-vars
 		response.status(error.status).send({
 			status: error.status,

--- a/test/integration/routes/components-(id)-details.test.js
+++ b/test/integration/routes/components-(id)-details.test.js
@@ -32,6 +32,13 @@ describe('GET /components/:componentId/details', () => {
                 assert.include(text, 'Bower Dependencies');
             });
 
+            it('includes the component\'s required browser features', () => {
+                assert.include(text, 'DOMTokenList');
+            });
+
+            it('includes the component\'s optional browser features', () => {
+                assert.include(text, 'IntersectionObserver');
+            });
         });
 
     });

--- a/views/details.html
+++ b/views/details.html
@@ -14,6 +14,12 @@
     {{#ifEither dependencies.bower.length dependencies.npm.length}}
         <nav class="o-layout__navigation">
             <ol>
+                {{#if browserFeatures.required.length}}
+                    <li><a href="#required-browser-features">Required Browser Features</a></li>
+                {{/if}}
+                {{#if browserFeatures.optional.length}}
+                    <li><a href="#optional-browser-features">Optional Browser Features</a></li>
+                {{/if}}
                 {{#if dependencies.bower.length}}
                     <li><a href="#bower">Bower Dependencies</a></li>
                 {{/if}}
@@ -26,6 +32,34 @@
 	</div>
 
     <div class="o-layout__main o-layout-typography" data-o-component="o-syntax-highlight">
+
+        {{#ifEither browserFeatures.required.length browserFeatures.optional.length}}
+            {{#if browserFeatures.required.length}}
+                <h2 id="required-browser-features">Required Browser Features</h2>
+                <p>{{ component.name }}@^{{ component.version }} requires the following browser features:</p>
+                <ul>
+                {{#each browserFeatures.required}}
+                    <li>
+                        <code>{{ . }}</code>
+                    </li>
+                {{/each}}
+                </ul>
+
+            {{/if}}
+            {{#if browserFeatures.optional.length}}
+                <h2 id="optional-browser-features">Optional Browser Features</h2>
+                <p>{{ component.name }}@^{{ component.version }} works best for browsers which support the following features, but will handle cases where they are not avalible:</p>
+                <ul>
+                {{#each browserFeatures.optional}}
+                    <li>
+                        <code>{{ . }}</code>
+                    </li>
+                {{/each}}
+                </ul>
+            {{/if}}
+            <p>We recommend <a href="https://polyfill.io/v3/">polyfill.io</a> to add support for missing features to older browsers.</p>
+        {{/ifEither}}
+
         {{#ifEither dependencies.bower.length dependencies.npm.length}}
             {{#if dependencies.npm.length}}
                 <h2 id="npm">NPM Dependencies</h2>


### PR DESCRIPTION
Add browser features to component's detail page, along with npm and bower dependencies.

If not added to the readme manually, users can currently only access this information by 
inspecting `origami.json` in a component's repository.

<img width="1531" alt="Screenshot 2019-05-28 at 16 44 56" src="https://user-images.githubusercontent.com/10405691/58492160-46727980-8168-11e9-8ab4-40bc34715c25.png">
