### PR TITLE
Update default JSDoc node to display before a selection is made.

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -334,9 +334,12 @@ module.exports = app => {
 			// Generate navigation.
 			const navItems = JsDocNav.createNavigation(componentJsDoc);
 			// Find a default node which will be rendered before a selection is made.
+			// i.e. a class or constructor function named after the component
+			// `oExampleComponent` or `ExampleComponent`.
 			const defaultNode = allNodes.find(node =>
 				node.name &&
-				node.name.toLowerCase() === `${component.name.replace('-', '')}`
+				(node.name.toLowerCase() === `${component.name.replace('-', '')}` ||
+				node.name.toLowerCase() === `${component.name.replace('o-', '')}`)
 			);
 
 			response.render('jsdoc', {


### PR DESCRIPTION
When no JSDoc item is selected we need to show something
by default. Instead of this:
<img width="1445" alt="Screenshot 2019-07-15 at 13 46 05" src="https://user-images.githubusercontent.com/10405691/61217139-fabf6380-a706-11e9-8740-212bf27f3269.png">

Show this:
<img width="1445" alt="Screenshot 2019-07-15 at 13 46 11" src="https://user-images.githubusercontent.com/10405691/61217160-03b03500-a707-11e9-9398-fd3d59d6ab24.png">

We should show classes or constructor functions named after
the component without a leading `o`. E.g the JS class for
`o-forms` if `Forms`. This pattern is largely followed but
sometimes the leading `o` is present. E.g. the class for `o-table`
is `OTable` (this is what is currently used for the default node).

I don't believe the naming of the class is in the spec but perhaps 
should be. The leading `o` in component class names like 
`OTable` is the exception to an otherwise quite consistent pattern.