### PR TITLE
Return on first `next` call in route.

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -322,7 +322,7 @@ module.exports = app => {
 			const registryError = new Error(`Unable to load jsdocs for ${request.params.componentId}.`);
 			registryError.statusCode = error.statusCode === 404 ? 404 : 503;
 			registryError.message = error.statusCode === undefined ? registryError.message : `${registryError.message} Recieved a ${error.statusCode} response when requesting codedocs.`;
-			next(registryError);
+			return next(registryError);
 		}
 		try {
 			// Object with nodes by type with nested member nodes (e.g. classes with functions and property nodes attached).


### PR DESCRIPTION
[Resolves](https://sentry.io/organizations/nextftcom/issues/894288546/events/b732574d49694f3e87cfd3ef0345d180/)