### PR TITLE
Lazy load demos with `loading="lazy"`.

### DIFF
--- a/views/partials/component/type/demos.html
+++ b/views/partials/component/type/demos.html
@@ -28,7 +28,7 @@
 			<div class="registry__component--demo-display">
 				{{#if display.live}}
 					<div class="o-tabs__tabpanel" id="{{slugify title}}-demo-{{@index}}">
-						<iframe scrolling="yes" allowTransparency="true" src="{{supportingUrls.live}}" class="demo__live" title="{{capitalise title}} Live Demo"></iframe>
+						<iframe loading="lazy" scrolling="yes" allowTransparency="true" src="{{supportingUrls.live}}" class="demo__live" title="{{capitalise title}} Live Demo"></iframe>
 					</div>
 				{{/if}}
 				{{#if display.html}}
@@ -37,7 +37,7 @@
 							<button class="registry__demo-button select-html">Select Full Code Snippet</button>
 							<pre><code class='o-syntax-highlight--html'>{{{display.highlightedHTML}}}</code></pre>
 						{{else}}
-							<iframe scrolling="yes" allowTransparency="true" src="{{supportingUrls.html}}" class="demo__code" title="{{capitalise title}} HTML Code Snippet"></iframe>
+							<iframe loading="lazy" scrolling="yes" allowTransparency="true" src="{{supportingUrls.html}}" class="demo__code" title="{{capitalise title}} HTML Code Snippet"></iframe>
 						{{/if}}
 					</div>
 				{{/if}}

--- a/views/partials/component/type/images.html
+++ b/views/partials/component/type/images.html
@@ -3,7 +3,7 @@
 	<ul class="registry__component--image-grid o-layout__unstyled-element">
 		{{#images}}
 			<li id="{{slugify title}}" class="registry__component--image-item">
-				<img src="{{supportingUrls.w200}}" alt="{{title}}"/>
+				<img src="{{supportingUrls.w200}}" alt="{{title}}" loading="lazy" />
 				<p class="registry__component--image-title o-layout__unstyled-element">{{title}}</p>
 			</li>
 		{{/images}}


### PR DESCRIPTION
This is just a [Chrome thing](https://www.chromestatus.com/feature/5645767347798016).
There is [a draft proposal](https://github.com/whatwg/html/pull/3752).
It doesn't do anything on most demo pages, as Chrome's current
behavior is to lazy load iframes with a [distance of 4000px](https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/frame/settings.json5?q=LoadingDistanceThresholdPx&l=974)

Especially as it's not helping much currently, maybe we should ignore this until 
there's a standard, Google seems a tad boisterous...