### PR TITLE
Make component support messages friendlier

### DIFF
--- a/views/partials/component/messages.html
+++ b/views/partials/component/messages.html
@@ -1,73 +1,109 @@
 {{#unless component.support.isOrigami}}
-	<div class="o-message o-message--notice o-message--inner o-message--warning-light" data-o-component="o-message" data-close="false">
+	<div class="o-message o-message--notice o-message--inner o-message--inform" data-o-component="o-message" data-close="false">
 		<div class="o-message__container">
 			<div class="o-message__content">
 				<p class="o-message__content-main">
-					<span class="o-message__content-highlight">{{component.name}} is not maintained by the Origami team.</span>
-					<span class="o-message__content-detail">While this component may be used, we make no guarantees about the support status, though we will help if we can.</span>
+					<span class="o-message__content-highlight">
+						{{component.name}} is not maintained by the Origami team.
+					</span>
+					<span class="o-message__content-detail">
+						This means that the Origami team will not necessarily be able to help you
+						with support requests.
+						<a class="o-message__actions__secondary o-layout__unstyled-element" href="#help-support">The people who maintain this component</a>
+						may be able to offer support, but it's not guaranteed.
+					</span>
 				</p>
 			</div>
 		</div>
 	</div>
-{{else}}
-	{{#ifEquals component.support.status "experimental"}}
-		<div class="o-message o-message--notice o-message--inner o-message--warning-light" data-o-component="o-message" data-close="false">
-			<div class="o-message__container">
-				<div class="o-message__content">
-					<p class="o-message__content-main">
-						<span class="o-message__content-highlight">{{component.name}} is experimental.</span>
-						<span class="o-message__content-detail">This component is not guaranteed to be ready for production use, and the API should be considered unstable.</span>
-					</p>
-				</div>
-			</div>
-		</div>
-	{{/ifEquals}}
-
-	{{#ifEquals component.support.status "deprecated"}}
-		<div class="o-message o-message--notice o-message--inner o-message--warning-light" data-o-component="o-message" data-close="false">
-			<div class="o-message__container">
-				<div class="o-message__content">
-					<p class="o-message__content-main">
-						<span class="o-message__content-highlight">{{component.name}} is deprecated.</span>
-						<span class="o-message__content-detail">This component should not be used for new projects. Only security-related bugs will be fixed for this component, though existing implementations will continue to work.</span>
-					</p>
-				</div>
-			</div>
-		</div>
-	{{/ifEquals}}
-
-	{{#ifEquals component.support.status "dead"}}
-		<div class="o-message o-message--alert o-message--inner o-message--error" data-o-component="o-message" data-close="false">
-			<div class="o-message__container">
-				<div class="o-message__content">
-					<p class="o-message__content-main">
-						<span class="o-message__content-highlight">{{component.name}} is dead.</span>
-						<span class="o-message__content-detail">This component is known to be broken, or is very likely to break. There are no plans to fix any issues with this component.</span>
-					</p>
-				</div>
-			</div>
-		</div>
-	{{/ifEquals}}
-
-	{{#ifAny component.support.status 'active' 'maintained'}}
-		{{#if component.brandable }}
-			<div class="o-message o-message--notice o-message--inner o-message--inform" data-o-component="o-message" data-close="false">
-				<div class="o-message__container">
-					<div class="o-message__content">
-						{{#ifEquals versions.0.version component.version}}
-							<p class="o-message__content-main">
-								<span class="o-message__content-highlight">{{component.name}} hasn't been branded yet, it only supports the master brand.</span>
-								<span class="o-message__content-detail">If you would like to discuss having it branded <a class="o-message__actions__secondary o-layout__unstyled-element" href="#support"> please get in touch with the Origami team</a>.</span>
-							</p>
-						{{else}}
-							<p class="o-message__content-main">
-								<span class="o-message__content-highlight">This version of {{component.name}} hasn't been branded yet.</span>
-								<span class="o-message__content-detail">Please check the latest version, <a class="o-message__actions__secondary o-layout__unstyled-element" href="{{component.name}}@{{versions.0.version}}">{{versions.0.version}}</a>, as branding is a relatively new addition to our components.</span>
-							</p>
-						{{/ifEquals}}
-					</div>
-				</div>
-			</div>
-		{{/if}}
-	{{/ifAny}}
 {{/unless}}
+
+{{#ifEquals component.support.status "experimental"}}
+	<div class="o-message o-message--notice o-message--inner o-message--warning-light" data-o-component="o-message" data-close="false">
+		<div class="o-message__container">
+			<div class="o-message__content">
+				<p class="o-message__content-main">
+					<span class="o-message__content-highlight">
+						{{component.name}} has a support status of "experimental".
+					</span>
+					<span class="o-message__content-detail">
+						This means that the component's API may change without notice, and
+						there is no guarantee that the component is ready for production use.
+					</span>
+				</p>
+			</div>
+		</div>
+	</div>
+{{/ifEquals}}
+
+{{#ifEquals component.support.status "deprecated"}}
+	<div class="o-message o-message--notice o-message--inner o-message--warning-light" data-o-component="o-message" data-close="false">
+		<div class="o-message__container">
+			<div class="o-message__content">
+				<p class="o-message__content-main">
+					<span class="o-message__content-highlight">
+						{{component.name}} has a support status of "deprecated".
+					</span>
+					<span class="o-message__content-detail">
+						This means that no new features will be added to this component, but
+						security-related bugs will be fixed. We do not recommend using this
+						component in new projects. If you still rely on this component or have
+						concerns, please contact the Origami team.
+					</span>
+				</p>
+			</div>
+		</div>
+	</div>
+{{/ifEquals}}
+
+{{#ifEquals component.support.status "dead"}}
+	<div class="o-message o-message--alert o-message--inner o-message--error" data-o-component="o-message" data-close="false">
+		<div class="o-message__container">
+			<div class="o-message__content">
+				<p class="o-message__content-main">
+					<span class="o-message__content-highlight">
+						{{component.name}} has a support status of "dead".
+					</span>
+					<span class="o-message__content-detail">
+						This means that there are no plans to fix any issues with this
+						component, and it may stop working at any point. More information
+						on the status of this component is available
+						<a class="o-message__actions__secondary o-layout__unstyled-element" href="/components/{{component.name}}@{{component.version}}/readme{{#if @root.currentBrand}}?brand={{@root.currentBrand}}{{/if}}">in the README</a>.
+						If you still rely on this component or have concerns, please contact
+						the Origami team.
+					</span>
+				</p>
+			</div>
+		</div>
+	</div>
+{{/ifEquals}}
+
+{{#ifAny component.support.status 'active' 'maintained'}}
+	{{#if component.brandable }}
+		<div class="o-message o-message--notice o-message--inner o-message--inform" data-o-component="o-message" data-close="false">
+			<div class="o-message__container">
+				<div class="o-message__content">
+					{{#ifEquals versions.0.version component.version}}
+						<p class="o-message__content-main">
+							<span class="o-message__content-highlight">
+								{{component.name}} hasn't been branded yet, it only supports the master brand.
+							</span>
+							<span class="o-message__content-detail">
+								If you would like to discuss having it branded <a class="o-message__actions__secondary o-layout__unstyled-element" href="#support"> please get in touch with the Origami team</a>.
+							</span>
+						</p>
+					{{else}}
+						<p class="o-message__content-main">
+							<span class="o-message__content-highlight">
+								This version of {{component.name}} hasn't been branded yet.
+							</span>
+							<span class="o-message__content-detail">
+								Please check the latest version, <a class="o-message__actions__secondary o-layout__unstyled-element" href="{{component.name}}@{{versions.0.version}}">{{versions.0.version}}</a>, as branding is a relatively new addition to our components.
+							</span>
+						</p>
+					{{/ifEquals}}
+				</div>
+			</div>
+		</div>
+	{{/if}}
+{{/ifAny}}


### PR DESCRIPTION
This updates all of the component support messages to be a little
friendlier. I've also allowed the "not maintained by Origami" and the
support level messages to appear alongside eachother. My logic for
this change is that if we want more non-Origami-maintained components
in the registry then users of those components still deserve to see
information about the support level.

<table>
	<thead>
		<tr>
			<th>Old text</th>
			<th>New text</th>
		</tr>
	</thead>
	<tbody>
		<tr>
			<td><strong>o-example is experimental.</strong> This component is not guaranteed to be ready for production use, and the API should be considered unstable.</td>
			<td><strong>o-example has a support status of "experimental".</strong> This means that the component's API may change without notice, and there is no guarantee that the component is ready for production use.</td>
		</tr>
		<tr>
			<td><strong>o-example is deprecated.</strong> This component should not be used for new projects. Only security-related bugs will be fixed for this component, though existing implementations will continue to work.</td>
			<td><strong>o-example has a support status of "deprecated".</strong> This means that no new features will be added to this component, but security-related bugs will be fixed. We do not recommend using this component in new projects. If you still rely on this component or have concerns, please contact the Origami team.</td>
		</tr>
		<tr>
			<td><strong>o-example is dead.</strong> This component is known to be broken, or is very likely to break. There are no plans to fix any issues with this component.</td>
			<td><strong>o-example has a support status of "dead".</strong> This means that there are no plans to fix any issues with this component, and it may stop working at any point. More information on the status of this component is available <a href="#nope">in the README</a>. If you still rely on this component or have concerns, please contact the Origami team.</td>
		</tr>
		<tr>
			<td><strong>o-example is not maintained by the Origami team.</strong> While this component may be used, we make no guarantees about the support status, though we will help if we can.</td>
			<td><strong>o-example is not maintained by the Origami team.</strong> This means that the Origami team will not necessarily be able to help you with support requests. The <a href="#nope">people who maintain this component</a> may be able to offer support, but it's not guaranteed.</td>
		</tr>
	</tbody>
</table>