### PR TITLE
Improve codedocs parameter table layout.

### DIFF
--- a/src/scss/component/_codedocs.scss
+++ b/src/scss/component/_codedocs.scss
@@ -12,7 +12,9 @@
     display: none;
 }
 
-.o-table--code-docs .o-table__code-docs-shrink {
-    width: 0.1%;
-    white-space: nowrap;
+// Wrap column content to fit the given width
+// where possible.
+.parameter-table-header--default,
+.parameter-table-header--description {
+    width: 40%;
 }

--- a/views/partials/codedocs/nodes/sections/parameters-table.html
+++ b/views/partials/codedocs/nodes/sections/parameters-table.html
@@ -4,17 +4,17 @@
             <table class="o-table o-table--horizontal-lines o-table--responsive-overflow o-table--code-docs" data-o-table-sortable="false" data-o-component="o-table" data-o-table-responsive="overflow">
                 <thead>
                     <tr>
-                        <th scope="col" role="columnheader" class="o-table__code-docs-shrink">parameter</th>
-                        <th scope="col" role="columnheader" class="o-table__code-docs-shrink">type</th>
-                        <th scope="col" role="columnheader" class="o-table__code-docs-shrink">default</th>
-                        <th scope="col" role="columnheader">description</th>
+                        <th scope="col" role="columnheader" class="parameter-table-header parameter-table-header--parameter ">parameter</th>
+                        <th scope="col" role="columnheader" class="parameter-table-header parameter-table-header--type ">type</th>
+                        <th scope="col" role="columnheader" class="parameter-table-header parameter-table-header--default ">default</th>
+                        <th scope="col" role="columnheader" class="parameter-table-header parameter-table-header--description ">description</th>
                     </tr>
                 </thead>
                 <tbody>
                     {{#each this}}
                     <tr>
-                        <td class="o-table__code-docs-shrink">{{name}}{{#if optional}} (optional){{/if}}</td>
-                        <td class="o-table__code-docs-shrink">
+                        <td>{{name}}{{#if optional}} (optional){{/if}}</td>
+                        <td>
                             {{#each types}}
                                 {{#if this.longname}}
                                     <a class="link" href="#{{slugify this.name}}">{{ this.name }}</a>
@@ -25,7 +25,7 @@
                             {{/each}}
 
                         </td>
-                        <td class="o-table__code-docs-shrink">{{default}}</td>
+                        <td>{{default}}</td>
                         <td>{{description}}</td>
                     </tr>
                     {{/each}}


### PR DESCRIPTION
Wrap column content to fit a given width. Improves the display of
parameters with long default values, e.g. Sass maps

Before:
<img width="1433" alt="Screenshot 2020-02-28 at 11 16 20" src="https://user-images.githubusercontent.com/10405691/75544567-2d129c80-5a1c-11ea-93ec-6a06d7f5f534.png">

After:
<img width="1433" alt="Screenshot 2020-02-28 at 11 16 17" src="https://user-images.githubusercontent.com/10405691/75544574-326fe700-5a1c-11ea-9bbd-3babd5b65e9a.png">
