### PR TITLE
Do not run demo html select JS until `o.DOMContentLoaded` has fired.

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -4,8 +4,8 @@ require('o-syntax-highlight');
 require('o-layout');
 require('./click-helper');
 require('./demo');
-require('./select-text');
 
+const SelectText = require('./select-text');
 const Versioning = require('./versioning');
 const FilterableNav = require('./filterable-nav');
 const ComponentListing = require('./component-listing');
@@ -17,4 +17,5 @@ document.addEventListener('o.DOMContentLoaded', () => {
 	ComponentListing.init();
 	FilterForm.init();
 	Versioning.init();
+	SelectText.init();
 });

--- a/src/js/select-text.js
+++ b/src/js/select-text.js
@@ -17,8 +17,8 @@ function selectText(element) {
 	}
 }
 
-module.exports = (function() {
-	const buttons = document.querySelectorAll('.select-html');
+module.exports.init = (function() {
+	const buttons = document.querySelectorAll('[data-select-html]');
 	if (buttons) {
 		buttons.forEach(button => {
 			button.addEventListener('click', (e) => {

--- a/src/scss/component/_demos.scss
+++ b/src/scss/component/_demos.scss
@@ -20,11 +20,11 @@
 	@include oButtons($theme: 'mono');
 }
 
-.core .select-html {
+.core .registry__demo-button--select-html {
 	display: none;
 }
 
-.registry__demo-button.select-html {
+.registry__demo-button--select-html {
 	position: absolute;
 	top: oTypographySpacingSize(2);
 	right: oTypographySpacingSize(2);

--- a/views/partials/component/type/demos.html
+++ b/views/partials/component/type/demos.html
@@ -34,7 +34,7 @@
 				{{#if display.html}}
 					<div class="o-tabs__tabpanel" id="{{slugify title}}-html-{{@index}}">
 						{{#if display.plainHTML}}
-							<button class="registry__demo-button select-html">Select Full Code Snippet</button>
+							<button class="registry__demo-button registry__demo-button--select-html" data-select-html>Select Full Code Snippet</button>
 							<pre><code class='o-syntax-highlight--html'>{{{display.highlightedHTML}}}</code></pre>
 						{{else}}
 							<iframe scrolling="yes" allowTransparency="true" src="{{supportingUrls.html}}" class="demo__code" title="{{capitalise title}} HTML Code Snippet"></iframe>


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/origami-registry-ui/issues/105