### PR TITLE
Add padding to demo html.

### DIFF
--- a/src/scss/component/_demos.scss
+++ b/src/scss/component/_demos.scss
@@ -8,7 +8,14 @@
 		border-bottom: 1px solid oColorsGetPaletteColor('slate-white-15');
 		position: relative;
 
-		.demo__code,
+		.demo__html {
+			// Add padding to demo html so overlaying controls
+			// i.e. "select full code snippet" do not visually
+			// obscure demo html
+			display: inline-block;
+			padding-right: 10rem;
+		}
+
 		.demo__live {
 			width: 100%;
 			border: 0;

--- a/views/partials/component/type/demos.html
+++ b/views/partials/component/type/demos.html
@@ -35,9 +35,9 @@
 					<div class="o-tabs__tabpanel" id="{{slugify title}}-html-{{@index}}">
 						{{#if display.plainHTML}}
 							<button class="registry__demo-button registry__demo-button--select-html" data-select-html>Select Full Code Snippet</button>
-							<pre><code class='o-syntax-highlight--html'>{{{display.highlightedHTML}}}</code></pre>
+							<pre><code class='demo__html o-syntax-highlight--html'>{{{display.highlightedHTML}}}</code></pre>
 						{{else}}
-							<iframe scrolling="yes" allowTransparency="true" src="{{supportingUrls.html}}" class="demo__code" title="{{capitalise title}} HTML Code Snippet"></iframe>
+							<iframe scrolling="yes" allowTransparency="true" src="{{supportingUrls.html}}" class="demo__live" title="{{capitalise title}} HTML Code Snippet"></iframe>
 						{{/if}}
 					</div>
 				{{/if}}


### PR DESCRIPTION
Add padding to demo html so overlaying controls i.e. "select full
code snippet" do not visually obscure demo html.

Fixes:
https://github.com/Financial-Times/origami-registry-ui/issues/233