### PR TITLE
Style o-tabs fallback links in core experience

### DIFF
--- a/views/partials/component/type/demos.html
+++ b/views/partials/component/type/demos.html
@@ -14,11 +14,11 @@
 						{{#if display.html}}
 							{{#if display.live}}
 								<li role="tab">
-									<a href="#{{slugify title}}-demo-{{@index}}" class="o-layout__unstyled-element">Demo</a>
+									<a href="#{{slugify title}}-demo-{{@index}}">Demo</a>
 								</li>
 							{{/if}}
 							<li role="tab">
-								<a href="#{{slugify title}}-html-tabpanel-{{@index}}" class="o-layout__unstyled-element">HTML</a>
+								<a href="#{{slugify title}}-html-tabpanel-{{@index}}">HTML</a>
 							</li>
 						{{/if}}
 					</ul>


### PR DESCRIPTION
When JavaScript fails or is disabled, o-tabs falls back to links.
Style these as usual links instead of using the browser defaults.

before
<img width="970" alt="Screenshot 2020-04-07 at 10 38 16" src="https://user-images.githubusercontent.com/10405691/78654155-0e75b000-78bc-11ea-835f-c997e1d5f057.png">

after
<img width="1046" alt="Screenshot 2020-04-07 at 10 38 05" src="https://user-images.githubusercontent.com/10405691/78654176-146b9100-78bc-11ea-9109-2df57d0bc5e7.png">
