### PR TITLE
Fix demo iframe resizing when JS is compiled by `swc`.

### DIFF
--- a/src/js/demo.js
+++ b/src/js/demo.js
@@ -1,9 +1,9 @@
 
 
 export default (function(){
-	window.addEventListener('message', (e) => {
+	window.addEventListener('message', (event) => {
 		try {
-			const data = JSON.parse(e.data);
+			const data = JSON.parse(event.data);
 			if (data.type === 'resize' && data.url && data.height) {
 				const iframesToResize = document.querySelectorAll(`iframe[src="${data.url}"]`);
 				iframesToResize.forEach((iframe) => {


### PR DESCRIPTION
For some reason the output of `swc` is:

```
window.addEventListener('message', function (e1) { try { var data = JSON.parse(e.data); if (data.type === 'resize' && data.url && data.height) { var iframesToResize = document.querySelectorAll('iframe[src="'.concat(data.url, '"]')); iframesToResize.forEach(function (iframe) { iframe.height = data.height; }); } } catch (e) { } }, false)
```

Note `swc` has renamed the `e` parameter of the event listener
to `e1` but `e` is still used within the function.

This commit prevents `swc` from doing this.

```
window.addEventListener('message', function (event) { try { var data = JSON.parse(event.data); if (data.type === 'resize' && data.url && data.height) { var iframesToResize = document.querySelectorAll('iframe[src="'.concat(data.url, '"]')); iframesToResize.forEach(function (iframe) { iframe.height = data.height; }); } } catch (e) { } }, false);
```

I'm unsure what the root cause is (probably related to the section `e` parameter used within the catch block).