### PR TITLE
Use the new $default-branch macro instead of hardcoding the branch name

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -2,7 +2,7 @@ name: Deploy to staging
 on:
   push:
     branches:
-      - master
+      - $default-branch
 
 jobs:
   deploy-to-staging:


### PR DESCRIPTION
This will help with any future wok on renaming the default branch name.