### PR TITLE
pin terraform version to the last version before 0.13 which has breaking changes

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [created]
 env:
-  terraform_version: 'latest'
+  terraform_version: '0.12.29'
   terraform_working_dir: 'fastly/terraform/'
   fastly_service_id: '7mnWDqaHxkKwIFASbvnV13'
 jobs:


### PR DESCRIPTION
This is currently stopping automated releases from getting into production