### PR TITLE
use o-tracking v3 via the tag instead of a branch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "o-forms": "^8.3.2",
     "o-spacing": "^2.0.1",
     "o-icons": "^6.0.3",
-    "o-tracking": "v3",
+    "o-tracking": "^3",
     "o-cookie-message": "^5.0.6"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "o-forms": "^8.3.2",
     "o-spacing": "^2.0.1",
     "o-icons": "^6.0.3",
-    "o-tracking": "^3",
+    "o-tracking": "^3.0.0",
     "o-cookie-message": "^5.0.6"
   }
 }


### PR DESCRIPTION
The branch was deleted when it got merged to the default branch and so right now a `bower install` on this repo fails stating it can not find o-tracking's v3 branch.