### PR TITLE
Handle no component readme.

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -420,13 +420,61 @@ module.exports = app => {
 		}
 	});
 
+	/**
+	 * A message object.
+	 *
+	 * @typedef {Object} Message
+	 * @property {String} type - An o-message type.
+	 * @property {String} state - An o-message state.
+	 * @property {String} content - Main message content.
+	 * @property {String} [detail] - Additional message content.
+	 */
+
+	/**
+	 * Get the readme for a component.
+	 *
+	 * @param {Object} component - The component included in the request.
+	 * @param {String} component.repo
+	 * @param {String} component.id
+	 * @param {String} component.name
+	 * @param {String} component.version
+	 *
+	 * @return {String|Message}
+	 */
+	async function getReadme(component) {
+		try {
+			return await app.repoData.getMarkdown(component.repo, component.id, 'readme');
+		} catch (error) {
+			if (error.status !== 404) {
+				return {
+					type: 'alert',
+					state: 'error',
+					content: `Could not load README for ${component.name} at ${component.version}. ` +
+						`Error: ${error.status}. Please contact the team for support.`
+				};
+			}
+
+			return {
+				type: 'notice',
+				state: 'inform',
+				content: `${component.name} at ${component.version} has no README. ` +
+					'Please contact the team for support.'
+			};
+		}
+
+	}
+
 	// Individual component readme page
 	app.get('/components/:componentId/readme', cacheForFiveMinutes, findComponentId, switchBrandAndVersion, findComponent, findBrand, async (request, response, next) => {
 		const component = request.component;
 		const versions = request.versions;
 		const currentBrand = request.currentBrand;
+
+		const readmeResult = await getReadme(component);
+		const readmeMarkdown = typeof readmeResult === 'string' ? readmeResult : '';
+		const readmeMessage = typeof readmeResult === 'object' ? readmeResult : undefined;
+
 		try {
-			const readmeMarkdown = await app.repoData.getMarkdown(component.repo, component.id, 'readme');
 			const readme = new ReadMe(readmeMarkdown, component.versionTag, component.url, request.headers.host);
 			const navItems = readme.createNavigation();
 
@@ -439,7 +487,8 @@ module.exports = app => {
 				readme,
 				navItems,
 				nav: 'readme',
-				heading: 'Readme'
+				heading: 'Readme',
+				message: readmeMessage
 			});
 		} catch (error) {
 			const registryError = new Error(`Unable to load README for ${request.componentId}.`);

--- a/test/integration/mock/repo-data-api/data/repos.js
+++ b/test/integration/mock/repo-data-api/data/repos.js
@@ -49,6 +49,51 @@ module.exports = [
 		// mock use only
 		_versions: ['2.0.0', '1.1.1', '1.1.0', '1.0.1', '1.0.0']
 	},
+	// Active Origami component with no readme
+	{
+		name: 'o-example-no-readme',
+		type: 'module',
+		subType: 'primitives',
+		version: '2.0.0',
+		support: {
+			status: 'active',
+			email: 'origami@example.com',
+			channel: {
+				name: '#example-channel',
+				url: 'mock-channel-url'
+			},
+			isOrigami: true
+		},
+		resources: {
+			demos: null,
+			dependencies: [
+				{
+					'name': 'example-dependency',
+					'version': '^1.2.3',
+					'source': 'bower',
+					'isDev': false,
+					'isOptional': false
+				}
+			]
+		},
+		manifests: {
+			'origami': {
+				'browserFeatures': {
+					'required': [
+						'DOMTokenList'
+					],
+					'optional': [
+						'IntersectionObserver'
+					]
+				}
+			}
+		},
+		markdown: {
+		},
+
+		// mock use only
+		_versions: ['2.0.0', '1.1.1', '1.1.0', '1.0.1', '1.0.0']
+	},
 
 	// Maintained Origami component
 	{

--- a/test/integration/routes/components-(id)-readme.test.js
+++ b/test/integration/routes/components-(id)-readme.test.js
@@ -108,4 +108,40 @@ describe('GET /components/:componentId/readme', () => {
 
     });
 
+    describe('when the named component version does not have a readme', () => {
+
+        beforeEach(async () => {
+            request = agent.get('/components/o-example-no-readme@2.0.0/readme');
+        });
+
+        it('responds with a 200 status', () => {
+            return request.expect(200);
+        });
+
+        it('responds with HTML', () => {
+            return request.expect('Content-Type', /text\/html/);
+        });
+
+        // Assertions here are based on data in `../mock/repo-data-api/data`
+        describe('HTML response', () => {
+            let dom;
+
+            beforeEach(async () => {
+                dom = new JSDOM((await request.then()).text);
+            });
+
+            it('includes a canonical url for the latest component version', () => {
+                const html = dom.window.document.documentElement.outerHTML;
+                assert.include(html, '<link rel="canonical" href="/components/o-example-no-readme/readme">');
+            });
+
+            it('includes a notice that there is no readme for the component version selected', () => {
+                const document = dom.window.document.documentElement;
+                assert.include(document.textContent.trim(), 'has no README');
+            });
+
+        });
+
+    });
+
 });

--- a/test/integration/routes/components.json.test.js
+++ b/test/integration/routes/components.json.test.js
@@ -21,7 +21,7 @@ describe('GET /components.json', () => {
         it('contains a list of all components', async () => {
             const request = agent.get('/components.json');
             const json = (await request.then()).body;
-            assert.equal(json.length, 7, 'Expected 7 components.');
+            assert.equal(json.length, 8, 'Expected 8 components.');
         });
 
         it('filters by search query parameter', async () => {
@@ -35,7 +35,7 @@ describe('GET /components.json', () => {
             const tests = [
                 {
                     type: 'module',
-                    expected: 5
+                    expected: 6
                 },
                 {
                     type: 'service',
@@ -57,7 +57,7 @@ describe('GET /components.json', () => {
             const tests = [
                 {
                     status: 'active',
-                    expected: 2
+                    expected: 3
                 },
                 {
                     status: 'maintained',
@@ -86,7 +86,7 @@ describe('GET /components.json', () => {
         it('filters with combined search, status, and type query parameters', async () => {
             const request = agent.get('/components.json?search=o-example&maintained=true&module=true');
             const json = (await request.then()).body;
-            assert.equal(json.length, 2, 'Expected to find 1 component(s) for a combined filter.');
+            assert.equal(json.length, 2, 'Expected to find 2 component(s) for a combined filter.');
         });
     });
 });

--- a/test/integration/routes/components.test.js
+++ b/test/integration/routes/components.test.js
@@ -33,7 +33,7 @@ describe('GET /components', () => {
 			assert.isNotNull(list);
 
 			const listItems = list.querySelectorAll('[data-test=component-list-item]');
-			assert.lengthEquals(listItems, 3);
+			assert.lengthEquals(listItems, 4);
 
 			let link;
 
@@ -42,10 +42,14 @@ describe('GET /components', () => {
 			assert.include(link.textContent.trim(), 'o-example-active');
 
 			link = listItems[1].querySelector('[data-test=component-link]');
+			assert.strictEqual(link.getAttribute('href'), '/components/o-example-no-readme@2.0.0?brand=master');
+			assert.include(link.textContent.trim(), 'o-example-no-readme');
+
+			link = listItems[2].querySelector('[data-test=component-link]');
 			assert.strictEqual(link.getAttribute('href'), '/components/o-example-maintained@1.5.0?brand=master');
 			assert.include(link.textContent.trim(), 'o-example-maintained');
 
-			link = listItems[2].querySelector('[data-test=component-link]');
+			link = listItems[3].querySelector('[data-test=component-link]');
 			assert.strictEqual(link.getAttribute('href'), '/components/o-example-imageset-maintained@1.5.0?brand=master');
 			assert.include(link.textContent.trim(), 'o-example-imageset-maintained');
 		});

--- a/views/partials/component/messages.html
+++ b/views/partials/component/messages.html
@@ -107,3 +107,22 @@
 		</div>
 	{{/if}}
 {{/ifAny}}
+
+{{#if message }}
+	<div class="o-message o-message--{{message.type}} o-message--inner o-message--{{message.state}}" data-o-component="o-message" data-close="false">
+		<div class="o-message__container">
+			<div class="o-message__content">
+				<p class="o-message__content-main">
+					<span class="o-message__content-highlight">
+						{{ message.content }}
+					</span>
+					{{#if message.detail }}
+					<span class="o-message__content-detail">
+						{{message.detail}}
+					</span>
+					{{/if}}
+				</p>
+			</div>
+		</div>
+	</div>
+{{/if}}


### PR DESCRIPTION
- Display notice message if repo data returns no readme (404).
- Display an error message within the page if repo data returns
no readme due to a non-404 error. This is instead of showing
a generic error page with no other context.

Solves: https://sentry.io/share/issue/33e3a3d4f2f24cc09b01ff1ce0f42840/

Before:
![Screenshot 2020-10-23 at 08 42 17](https://user-images.githubusercontent.com/10405691/96973047-46b6a600-150f-11eb-9126-b90368d7ce36.png)

After:
![Screenshot 2020-10-23 at 08 42 20](https://user-images.githubusercontent.com/10405691/96973065-4e764a80-150f-11eb-96aa-e2828d974458.png)
