### PR TITLE
Remove registry search selection on pressing enter

### DIFF
--- a/src/js/filter-form.js
+++ b/src/js/filter-form.js
@@ -69,17 +69,16 @@ class FilterForm {
 	 */
 	handleFormChangeEventImmediate(event) {
 		const queryString = this.getUrlEncodedFilterValues();
-		const feelingLucky = event && event.type === 'submit';
 
 		// If the filters haven't changed, exit early. Otherwise
 		// set the last filter to the new value
-		if (this.lastFilter === queryString && !feelingLucky) {
+		if (this.lastFilter === queryString) {
 			return;
 		}
 		this.lastFilter = queryString;
 
 		// Perform the search
-		return this.searchForRepos(feelingLucky).then(() => {
+		return this.searchForRepos().then(() => {
 			if (this.alterBrowserHistory) {
 				window.history.pushState({
 					oFilterFormFilters: this.getFilterValues()
@@ -91,7 +90,7 @@ class FilterForm {
 	/**
 	 * Search for repositories based on a set of filters
 	 */
-	searchForRepos(feelingLucky) {
+	searchForRepos() {
 		const loadingClass = 'registry__form--loading';
 		this.formElement.classList.add(loadingClass);
 		document.dispatchEvent(new CustomEvent('o.filterFormInitSearch'));
@@ -100,10 +99,6 @@ class FilterForm {
 				return response.json();
 			})
 			.then(repos => {
-				if (feelingLucky && repos.length) {
-					document.location = `/components/${repos[0].name}@${repos[0].version}`;
-					return;
-				}
 				this.formElement.classList.remove(loadingClass);
 				document.dispatchEvent(new CustomEvent('o.filterFormSuccess', {
 					detail: {


### PR DESCRIPTION
When you type into the Origami search there is no indication that you are currently focused on an element, sometimes you can have multiple results for a single keyword.

This means when you press enter it will go to a page when the expected behaviour is to show all results.

To reproduce the undesirable behaviour:

1. Go to https://registry.origami.ft.com/components?brand=master
2. Type 'header'
3. Press enter straight away

You're now on `o-headers`

This pull request is a proposal to essentially make submissions do nothing.