### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,14 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # Origami Registry UI
 
 Get information about Origami components, services, and repositories
+
+## Code
+
+origami-registry-ui
 
 ## Service Tier
 
@@ -20,35 +28,19 @@ Heroku
 
 ## Contains Personal Data
 
-no
+No
 
 ## Contains Sensitive Data
 
-no
+No
 
-## Delivered By
+## Can Download Personal Data
 
-origami-team
+No
 
-## Supported By
+## Can Contact Individuals
 
-origami-team
-
-## Known About By
-
-* jake.champion
-* lee.moody
-* rowan.manning
-
-## Dependencies
-
-* origami-repo-data
-* origami-codedocs
-
-## Healthchecks
-
-* registry.origami.ft.com-https
-* origami-registry-ui-eu.herokuapp.com-https
+No
 
 ## Failover Architecture Type
 
@@ -84,8 +76,6 @@ This is a Node.js application, and mostly exists as a presentation layer over th
 
 Most of the logic for the service is in the routes, and the most complex parts of the app relate to transforming data from the APIs into something that's useable by the view layer.
 
-[Google Drawing](https://docs.google.com/a/ft.com/drawings/d/1qKROLQvR-D5LzxxTTkJgzcr5IlLLkaRh3bEtF0AAYeA/edit?usp=sharing)
-
 ## More Information
 
 You can find more information on the live site.
@@ -96,14 +86,13 @@ This application is not critical outside of office hours, please contact the Ori
 
 If no member of the Origami team is available within office hours, check the status of healthchecks for more information or try restarting all of the dynos across the production Heroku apps ([pipeline here](https://dashboard.heroku.com/pipelines/c206786a-73a4-4cbc-90dc-58db19255704)).
 
-
 ## Second Line Troubleshooting
 
 If the application is failing entirely, you'll need to check a couple of things:
 
-1. Did a deployment just happen? If so, consider rolling it back.
-2. Check the Heroku metrics page for EU apps, to see what CPU and memory usage is like ([pipeline here](https://dashboard.heroku.com/pipelines/c206786a-73a4-4cbc-90dc-58db19255704))
-3. Check the CDN ([Fastly](https://manage.fastly.com/configure/services/7mnWDqaHxkKwIFASbvnV13/versions/9/domains)) is caching pages as expected.
+1.  Did a deployment just happen? If so, consider rolling it back.
+2.  Check the Heroku metrics page for EU apps, to see what CPU and memory usage is like ([pipeline here](https://dashboard.heroku.com/pipelines/c206786a-73a4-4cbc-90dc-58db19255704))
+3.  Check the CDN ([Fastly](https://manage.fastly.com/configure/services/7mnWDqaHxkKwIFASbvnV13/versions/9/domains)) is caching pages as expected.
 
 Always roll back a deploy if one happened just before the thing stopped working – this gives you the chance to debug in the relative calm of QA.
 
@@ -127,3 +116,10 @@ The application is deployed to QA whenever a new commit is pushed to the `master
 
 The only key used by this application is for Origami Repo Data. We rotate this manually.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/origami-registry-ui/blob/runbook-no-relationships-2021-03-19/RUNBOOK.md) file has been automatically regenerated from the Biz Ops data for the **origami-registry-ui** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **origami-registry-ui** system in [Biz Ops](https://biz-ops.in.ft.com/System/origami-registry-ui).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
