### PR TITLE
Correct v2 repo data mocks

### DIFF
--- a/test/integration/mock/repo-data-api/data/repos.js
+++ b/test/integration/mock/repo-data-api/data/repos.js
@@ -54,8 +54,8 @@ module.exports = [
 	{
 		name: 'o-example-v2',
 		type: 'module',
-		subType: 'primitives',
-		origamiVersion: 2.0,
+		subType: null,
+		origamiVersion: '2.0',
 		version: '2.0.0',
 		support: {
 			status: 'active',


### PR DESCRIPTION
The draft v2 spec is still changing, `subType` (a.k.a `origamiCateogry`)
no longer applies to spec v2 components and `origamiVersion` should
be a string.

https://github.com/Financial-Times/origami-website/pull/273