### PR TITLE
Show only stable releases as the latest/default release.

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -12,7 +12,8 @@ const ReadMe = require('../code-docs/readme');
 const requestUrl = require('request-promise-native');
 const Sassdoc = require('../code-docs/sassdoc');
 const SassDocNav = require('../code-docs/sassdoc/nav');
-const {slugify} = require('../helpers');
+const { slugify } = require('../helpers');
+const semver = require('semver');
 
 module.exports = app => {
 
@@ -84,9 +85,21 @@ module.exports = app => {
 			let component;
 			let mustRedirect = false;
 
+			// If no versions are found for the component name 404 immediately
+			if (!Array.isArray(versions)) {
+				throw httpError(404);
+			}
+
 			// Select the requested version of the component
 			if (!componentVersion || componentVersion === 'latest') {
-				component = versions[0];
+				const sortedVersions = versions
+					.sort((a, b) => {
+						return semver.rcompare(a.version, b.version);
+					});
+				const latestStableVersion = sortedVersions.find(repoDataVersion =>
+					semver.prerelease(repoDataVersion.version) === null
+				);
+				component = latestStableVersion || sortedVersions[0];
 				mustRedirect = true;
 			} else {
 				component = versions.find(version => version.version === componentVersion);
@@ -138,7 +151,7 @@ module.exports = app => {
 	};
 
 	// Component listing page
-	app.get('/components', cacheForFiveMinutes, findBrand, express.urlencoded({extended: false}), async (request, response, next) => {
+	app.get('/components', cacheForFiveMinutes, findBrand, express.urlencoded({ extended: false }), async (request, response, next) => {
 		try {
 			const currentBrand = request.currentBrand;
 
@@ -162,7 +175,7 @@ module.exports = app => {
 	});
 
 	// Component JSON search endpoint (an authenticated proxy for repo data search)
-	app.get('/components.json', cacheForFiveMinutes, express.urlencoded({extended: false}), async (request, response, next) => {
+	app.get('/components.json', cacheForFiveMinutes, express.urlencoded({ extended: false }), async (request, response, next) => {
 		try {
 			let repos = await app.repoData.listRepos(queryToRepoFilter(request.validQuery));
 			repos = await Promise.all(repos.map(repo => {
@@ -213,15 +226,15 @@ module.exports = app => {
 						demo.display.plainHTML = await requestUrl(demo.supportingUrls.html);
 						demo.display.highlightedHTML = prism.highlight(demo.display.plainHTML, prism.languages.html);
 					}));
-				} catch (error) {}
+				} catch (error) { }
 
-			// If the component is an image set and it has images, load them
+				// If the component is an image set and it has images, load them
 			} else if (component.type === 'imageset' && component.resources.images) {
 				images = await app.repoData.listImages(component.repo, component.id, {
 					sourceParam: 'origami-registry'
 				});
 
-			// If the component is a service and it has about data, load it
+				// If the component is a service and it has about data, load it
 			} else if (component.type === 'service' && component.resources.manifests.about) {
 				service = await app.repoData.getManifest(component.repo, component.id, 'about');
 			}
@@ -353,7 +366,7 @@ module.exports = app => {
 			const defaultNode = allNodes.find(node =>
 				node.name &&
 				(node.name.toLowerCase() === `${component.name.replace('-', '')}` ||
-				node.name.toLowerCase() === `${component.name.replace('o-', '')}`)
+					node.name.toLowerCase() === `${component.name.replace('o-', '')}`)
 			);
 
 			response.render('jsdoc', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5007,6 +5007,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-processinfo": {
@@ -5782,6 +5790,13 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "marked": {
@@ -7013,6 +7028,11 @@
           "requires": {
             "lowercase-keys": "^1.0.0"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -8284,9 +8304,12 @@
       "optional": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -8299,6 +8322,13 @@
       "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
       "requires": {
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "send": {
@@ -8657,6 +8687,13 @@
         "update-notifier": "^4.1.0",
         "uuid": "^3.3.2",
         "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "snyk-config": {
@@ -9192,6 +9229,11 @@
             "yallist": "^3.0.2"
           }
         },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
         "snyk-try-require": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/snyk-try-require/-/snyk-try-require-2.0.1.tgz",
@@ -9283,6 +9325,11 @@
         "tslib": "^1.10.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
         "tmp": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
@@ -10019,7 +10066,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "request-promise-native": "1.0.9",
     "require-all": "3.0.0",
     "sassdoc-extras": "3.0.0",
+    "semver": "^7.3.5",
     "showdown": "1.9.1",
     "snyk": "^1.518.0",
     "throng": "5.0.0"

--- a/test/integration/mock/repo-data-api/data/repos.js
+++ b/test/integration/mock/repo-data-api/data/repos.js
@@ -48,7 +48,7 @@ module.exports = [
 		},
 
 		// mock use only
-		_versions: ['2.0.0', '1.1.1', '1.1.0', '1.0.1', '1.0.0']
+		_versions: ['2.1.0-beta.0', '2.0.0', '1.1.1', '1.1.0', '1.0.1', '1.0.0']
 	},
 	// v2 Origami component
 	{

--- a/test/integration/routes/components-(id).test.js
+++ b/test/integration/routes/components-(id).test.js
@@ -66,7 +66,7 @@ describe('GET /components/:componentId', () => {
 			return request.expect(307);
 		});
 
-		it('responds with a Location header pointing to the latest version page', () => {
+		it('responds with a Location header pointing to the latest stable version page', () => {
 			return request.expect('Location', '/components/o-example-active@2.0.0');
 		});
 
@@ -82,7 +82,7 @@ describe('GET /components/:componentId', () => {
 			return request.expect(307);
 		});
 
-		it('responds with a Location header pointing to the latest version page', () => {
+		it('responds with a Location header pointing to the latest stable version page', () => {
 			return request.expect('Location', '/components/o-example-active@2.0.0');
 		});
 


### PR DESCRIPTION
Some beta demos are failing right now. That's fine, but Origami
users shouldn't have their workflow disrupted and shouldn't see that
there is an error with pre-releases unless they are looking.