### PR TITLE
Increase first byte timeout to be the same as Herokus

### DIFF
--- a/fastly/terraform/main.tf
+++ b/fastly/terraform/main.tf
@@ -21,7 +21,7 @@ resource "fastly_service_v1" "app" {
     between_bytes_timeout = 10000
     connect_timeout       = 1000
     error_threshold       = 0
-    first_byte_timeout    = 15000
+    first_byte_timeout    = 30000
     max_conn              = 200
     name                  = "EU"
     port                  = 80


### PR DESCRIPTION
Heroku has a 30 second first byte timeout, currently our fastly config will cut-off at 15 seconds

We should also investigate what is causing the response to take this long to generate

Resolves https://github.com/Financial-Times/origami-registry-ui/issues/611