### PR TITLE
Allow the repo-data url to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ We configure Origami Registry UI using environment variables. In development, co
 
   * `NODE_ENV`: The environment to run the application in. One of `production`, `development` (default), or `test` (for use in automated tests).
   * `PORT`: The port to run the application on.
+  * `REPO_DATA_API_URL`: The [Repo Data](repo-data) URL to use, this is useful for pointing at staging or development environments. Defaults to `'https://origami-repo-data.ft.com'`
   * `REPO_DATA_API_KEY`: The [Repo Data](repo-data) API key to use when authenticating with that service.
   * `REPO_DATA_API_SECRET`: The [Repo Data](repo-data) API secret to use when authenticating with that service.
   * `CODEDOCS_ENDPOINT`: The [Origami Codedocs](origami-codedocs) endpoint.

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const options = {
 	log: console,
 	name: 'Origami Registry',
 	origamiSite: 'https://origami.ft.com/',
+	repoDataApiUrl: process.env.REPO_DATA_API_URL || 'https://origami-repo-data.ft.com',
 	repoDataApiKey: process.env.REPO_DATA_API_KEY,
 	codedocsApiKey: process.env.CODEDOCS_API_KEY,
 	codedocsEndpoint: process.env.CODEDOCS_ENDPOINT,

--- a/lib/service.js
+++ b/lib/service.js
@@ -32,6 +32,7 @@ function service(options) {
 	app.health = health;
 
 	app.repoData = new RepoDataClient({
+		apiUrl: options.repoDataApiUrl,
 		apiKey: options.repoDataApiKey,
 		apiSecret: options.repoDataApiSecret
 	});

--- a/test/unit/lib/service.test.js
+++ b/test/unit/lib/service.test.js
@@ -48,6 +48,7 @@ describe('lib/service', () => {
 			options = {
 				environment: 'test',
 				port: 1234,
+				repoDataApiUrl: 'mock-repo-data-url',
 				repoDataApiKey: 'mock-repo-data-api-key',
 				repoDataApiSecret: 'mock-repo-data-api-secret'
 			};
@@ -118,6 +119,7 @@ describe('lib/service', () => {
 			assert.calledOnce(RepoDataClient);
 			assert.calledWithNew(RepoDataClient);
 			assert.calledWithExactly(RepoDataClient, {
+				apiUrl: 'mock-repo-data-url',
 				apiKey: 'mock-repo-data-api-key',
 				apiSecret: 'mock-repo-data-api-secret'
 			});


### PR DESCRIPTION
This allows us to use a staging/development environment for the version of repo-data that the registry uses