### PR TITLE
speed up demo pages by loading all the demos via iframes on the clientside

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -6,7 +6,6 @@ const httpError = require('http-errors');
 const JsDoc = require('../code-docs/jsdoc');
 const JsDocNav = require('../code-docs/jsdoc/nav');
 const NavNode = require('../code-docs/nav-node');
-const prism = require('prismjs');
 const queryToRepoFilter = require('../query-to-repo-filter');
 const ReadMe = require('../code-docs/readme');
 const requestUrl = require('request-promise-native');

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -220,14 +220,6 @@ module.exports = app => {
 					}
 				}
 
-				// fetch the plain HTML and higlight it so we can style it
-				try {
-					await Promise.all(demos.filter(demo => demo.display.html).map(async demo => {
-						demo.display.plainHTML = await requestUrl(demo.supportingUrls.html);
-						demo.display.highlightedHTML = prism.highlight(demo.display.plainHTML, prism.languages.html);
-					}));
-				} catch (error) { }
-
 				// If the component is an image set and it has images, load them
 			} else if (component.type === 'imageset' && component.resources.images) {
 				images = await app.repoData.listImages(component.repo, component.id, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "origami-registry-ui",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
@@ -39,7 +38,6 @@
         "guestlist": "2.3.0",
         "heroku-node-settings": "1.1.0",
         "http-errors": "1.8.0",
-        "prismjs": "1.24.0",
         "request-promise-native": "1.0.9",
         "require-all": "3.0.0",
         "sassdoc-extras": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "guestlist": "2.3.0",
     "heroku-node-settings": "1.1.0",
     "http-errors": "1.8.0",
-    "prismjs": "1.24.0",
     "request-promise-native": "1.0.9",
     "require-all": "3.0.0",
     "sassdoc-extras": "3.0.0",

--- a/views/partials/component/type/demos.html
+++ b/views/partials/component/type/demos.html
@@ -32,19 +32,12 @@
 			<div class="registry-demo-content">
 				{{#if display.live}}
 					<div class="o-tabs__tabpanel" id="{{slugify title}}-demo-{{@index}}">
-						<iframe scrolling="yes" allowTransparency="true" src="{{supportingUrls.live}}" class="registry-demo-content__live" title="{{capitalise title}} Live Demo"></iframe>
+						<iframe loading="lazy" scrolling="yes" allowTransparency="true" src="{{supportingUrls.live}}" class="registry-demo-content__live" title="{{capitalise title}} Live Demo"></iframe>
 					</div>
 				{{/if}}
 				{{#if display.html}}
 					<div class="o-tabs__tabpanel" id="{{slugify title}}-html-tabpanel-{{@index}}">
-						{{#if display.plainHTML}}
-							<span class="o--if-js registry-demo-content__html-controls">
-								<button class="o-buttons o-buttons--secondary o-buttons--mono" data-select-html="{{slugify title}}-html-code-{{@index}}">Select Full Code Snippet</button>
-							</span>
-							<pre><code id="{{slugify title}}-html-code-{{@index}}" class='registry-demo-content__html-code o-syntax-highlight--html'>{{{display.highlightedHTML}}}</code></pre>
-						{{else}}
-							<iframe scrolling="yes" allowTransparency="true" src="{{supportingUrls.html}}" class="registry-demo-content__live" title="{{capitalise title}} HTML Code Snippet"></iframe>
-						{{/if}}
+						<iframe loading="lazy" scrolling="yes" allowTransparency="true" src="{{supportingUrls.html}}" class="registry-demo-content__live" title="{{capitalise title}} HTML Code Snippet"></iframe>
 					</div>
 				{{/if}}
 			</div>


### PR DESCRIPTION
currently the demo html tab is created on the server side and this can cause respones to take a long time when a component has lots of demos

moving that work to the clientside can speed up the response time for those components and we can add lazy loading on the iframes so that the user-agent only loads and iframes document when it is in view (E.G. they have clicked the html tab or scrolled down the page to view a different demo)

This solution removes the syntax highlighting and button to select all the code and copy it to the clipboard.

I thought I'd open this pull-request to see what people's thoughts are to this smaller implementation. I'm happy to make a different pull-request which fetches the html code and highlights the syntax and adds the copy to clipboard button

You can view this on the review app --> https://origami-registry-ui-dev.herokuapp.com/components/o-teaser@6.0.2

***Edit***: As this is the only user of the demo/html endpoint of the build-service, we could update the build service to return a page with syntax highlighting and button to copy to the clipboard etc