### PR TITLE
Map deprecated "master" brand to the "core" brand.

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -45,16 +45,21 @@ module.exports = app => {
 			// Remove query params.
 			url = url.replace(/(\?.*)/g, '');
 			// Add brand query param.
-			url = url + (switchBrand && switchBrand !== 'master' ? `?brand=${switchBrand}` : '');
+			url = url + (switchBrand && switchBrand !== 'core' ? `?brand=${switchBrand}` : '');
 			return response.redirect(307, url);
 		}
 		next();
 	};
 
 	const findBrand = (request, response, next) => {
-		const defaultBrand = 'master';
+		const defaultBrand = 'core';
 		const component = request.component;
 		const supportedBrands = component && component.brands && component.brands.length ? component.brands : [defaultBrand];
+		// The master brand has been renamed the core brand.
+		const deprecatedMasterBrandIndex = supportedBrands.indexOf('master');
+		if(deprecatedMasterBrandIndex !== -1) {
+			supportedBrands.splice(deprecatedMasterBrandIndex, 1, 'core');
+		}
 		const currentBrand = request.validQuery.brand || defaultBrand;
 
 		// If the current brand is not supported by the component.
@@ -161,9 +166,20 @@ module.exports = app => {
 				experimental: false
 			});
 
+			const repos = await app.repoData.listRepos(queryToRepoFilter(query));
+			for (const repo of repos) {
+				// The master brand has been renamed the core brand.
+				if(Array.isArray(repo.brands)) {
+					const deprecatedMasterBrandIndex = repo.brands.indexOf('master');
+					if(deprecatedMasterBrandIndex !== -1) {
+						repo.brands.splice(deprecatedMasterBrandIndex, 1, 'core');
+					}
+				}
+			}
+
 			response.render('overview', {
 				title: app.ft.options.name,
-				repos: await app.repoData.listRepos(queryToRepoFilter(query)),
+				repos,
 				currentBrand,
 				filter: query,
 				heading: 'Origami Registry'
@@ -179,6 +195,12 @@ module.exports = app => {
 			let repos = await app.repoData.listRepos(queryToRepoFilter(request.validQuery));
 			repos = await Promise.all(repos.map(repo => {
 				return new Promise((resolve, reject) => {
+					if(Array.isArray(repo.brands)) {
+						const deprecatedMasterBrandIndex = repo.brands.indexOf('master');
+						if(deprecatedMasterBrandIndex !== -1) {
+							repo.brands.splice(deprecatedMasterBrandIndex, 1, 'core');
+						}
+					}
 					const renderContext = Object.assign({
 						layout: null
 					}, repo);
@@ -230,14 +252,6 @@ module.exports = app => {
 				service = await app.repoData.getManifest(component.repo, component.id, 'about');
 			}
 
-			// Load repositories for the sidebar
-			const repos = await app.repoData.listRepos({
-				status: [
-					'active',
-					'maintained'
-				]
-			});
-
 			// Check if component is brandable so that we can display a message
 			// (has css & js or only css, is a module and hasn't been branded)
 			if (component.brands && component.brands.length === 0 && component.isComponent) {
@@ -263,7 +277,6 @@ module.exports = app => {
 				component,
 				demos,
 				images,
-				repos,
 				service,
 				versions,
 				currentBrand,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "origami-registry-ui",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/scss/_status-labels.scss
+++ b/src/scss/_status-labels.scss
@@ -20,8 +20,8 @@
 	background-color: oColorsByName('black')
 ));
 
-@include oLabelsAddState('master', (
-	// Master brand "wheat" colour.
+@include oLabelsAddState('core', (
+	// Core brand "wheat" colour.
 	// Not available to internal brands. We
 	// could add it to the internal brand
 	// palette but then have to communicate
@@ -54,7 +54,7 @@
 
 @include oLabelsAddState('scss', (
 	// This is creating a Sass-like pink
-	// using a mix of master brand colours
+	// using a mix of core brand colours
 	// "velvet" and "candy". They are not
 	// available to internal brands but we
 	// don't really care about them staying

--- a/test/integration/lib/code-docs/sassdoc/index.test.js
+++ b/test/integration/lib/code-docs/sassdoc/index.test.js
@@ -8,35 +8,35 @@ const Function = require('../../../../../lib/code-docs/sassdoc/nodes/function');
 const Variable = require('../../../../../lib/code-docs/sassdoc/nodes/variable');
 
 describe('lib/code-docs/sassdoc/index', () => {
-    const masterBrandSassDoc = new SassDoc('o-example', 'master', sassDocExampleData);
+    const coreBrandSassDoc = new SassDoc('o-example', 'core', sassDocExampleData);
     const internalBrandSassDoc = new SassDoc('o-example', 'internal', sassDocExampleData);
 
     describe('getNodesByKind', () => {
-        const masterBrandNodesByKind = masterBrandSassDoc.getNodesByKind();
-        it('Returns an object with the expected number of mixins for the master brand', () => {
-            assert.equal(masterBrandNodesByKind.mixin.length, 7);
+        const coreBrandNodesByKind = coreBrandSassDoc.getNodesByKind();
+        it('Returns an object with the expected number of mixins for the core brand', () => {
+            assert.equal(coreBrandNodesByKind.mixin.length, 7);
         });
-        it('Returns an object with the expected number of functions for the master brand', () => {
-            assert.equal(masterBrandNodesByKind.function.length, 2);
+        it('Returns an object with the expected number of functions for the core brand', () => {
+            assert.equal(coreBrandNodesByKind.function.length, 2);
         });
-        it('Returns an object with the expected number of variables for the master brand', () => {
-            assert.equal(masterBrandNodesByKind.variable.length, 4);
+        it('Returns an object with the expected number of variables for the core brand', () => {
+            assert.equal(coreBrandNodesByKind.variable.length, 4);
         });
     });
 
     describe('getNodes', () => {
-        const masterBrandNodes = masterBrandSassDoc.getNodes();
-        it('Did not return array for the master brand.', () => {
-            assert.isTrue(Array.isArray(masterBrandNodes));
+        const coreBrandNodes = coreBrandSassDoc.getNodes();
+        it('Did not return array for the core brand.', () => {
+            assert.isTrue(Array.isArray(coreBrandNodes));
         });
-        it('Returns the expected number of formatted mixin nodes for the master brand.', () => {
-            assert.equal(masterBrandNodes.filter(node => node instanceof Mixin).length, 7);
+        it('Returns the expected number of formatted mixin nodes for the core brand.', () => {
+            assert.equal(coreBrandNodes.filter(node => node instanceof Mixin).length, 7);
         });
-        it('Returns the expected number of formatted function nodes for the master brand.', () => {
-            assert.equal(masterBrandNodes.filter(node => node instanceof Function).length, 2);
+        it('Returns the expected number of formatted function nodes for the core brand.', () => {
+            assert.equal(coreBrandNodes.filter(node => node instanceof Function).length, 2);
         });
-        it('Returns the expected number of formatted variable nodes for the master brand.', () => {
-            assert.equal(masterBrandNodes.filter(node => node instanceof Variable).length, 4);
+        it('Returns the expected number of formatted variable nodes for the core brand.', () => {
+            assert.equal(coreBrandNodes.filter(node => node instanceof Variable).length, 4);
         });
 
         const internalBrandNodes = internalBrandSassDoc.getNodes();
@@ -47,7 +47,7 @@ describe('lib/code-docs/sassdoc/index', () => {
             assert.equal(
                 internalBrandNodes.filter(node => node instanceof Mixin).length,
                 5,
-                'Expected the internal brand to have fewer mixins than the master brand in this case.'
+                'Expected the internal brand to have fewer mixins than the core brand in this case.'
             );
         });
         it('Returns the expected number of formatted function nodes for the internal brand.', () => {

--- a/test/integration/mock/repo-data-api/data/repos.js
+++ b/test/integration/mock/repo-data-api/data/repos.js
@@ -287,7 +287,7 @@ module.exports = [
 					'title': 'example',
 					'description': 'example',
 					'brands': [
-						'master',
+						'core',
 						'internal'
 					]
 				}

--- a/test/sassdoc.json
+++ b/test/sassdoc.json
@@ -445,7 +445,7 @@
         ],
         "brand": {
             "supported": [
-                "master"
+                "core"
             ],
             "description": ""
         },
@@ -497,7 +497,7 @@
         "output": "Modifiying, cosmetic styles to make a test component fit the marketing look.",
         "brand": {
             "supported": [
-                "master"
+                "core"
             ],
             "description": ""
         },
@@ -529,7 +529,7 @@
         "brand": {
             "supported": [
                 "internal",
-                "master"
+                "core"
             ],
             "description": ""
         },

--- a/test/unit/lib/code-docs/sassdoc/index.test.js
+++ b/test/unit/lib/code-docs/sassdoc/index.test.js
@@ -12,7 +12,7 @@ const VariableDoclet = require('../../../mock/code-docs/sassdoc/variable');
 describe('lib/code-docs/sassdoc/index', () => {
 
     it('has a groupNameAliases property which maps a group name of "undefined" to the component name', () => {
-        const testSassDoc = new SassDoc('o-test-component', 'master', []);
+        const testSassDoc = new SassDoc('o-test-component', 'core', []);
         assert.deepEqual(testSassDoc.groupNameAliases, {
             'undefined': 'o-test-component',
         });
@@ -26,7 +26,7 @@ describe('lib/code-docs/sassdoc/index', () => {
     });
 
     describe('getNodesByKind', () => {
-        const testSassDoc = new SassDoc('o-test-component', 'master', [
+        const testSassDoc = new SassDoc('o-test-component', 'core', [
             MixinDoclet.simpleDoclet,
             MixinDoclet.comprehensiveDoclet,
             FunctionDoclet.simpleDoclet,
@@ -74,7 +74,7 @@ describe('lib/code-docs/sassdoc/index', () => {
 
     describe('getNodes', () => {
         const componentName = 'o-example';
-        const brand = 'master';
+        const brand = 'core';
         let doclet = {};
 
         beforeEach(() => {

--- a/test/unit/lib/code-docs/sassdoc/nav.test.js
+++ b/test/unit/lib/code-docs/sassdoc/nav.test.js
@@ -10,7 +10,7 @@ const VariableDoclet = require('../../../mock/code-docs/sassdoc/variable');
 
 describe('lib/code-docs/sassdoc/nav', () => {
     describe('createNavigation', () => {
-        const testSassDoc = new SassDoc('o-test-component', 'master', [
+        const testSassDoc = new SassDoc('o-test-component', 'core', [
             FunctionDoclet.simpleDoclet,
             FunctionDoclet.comprehensiveDoclet,
             VariableDoclet.simpleDoclet,

--- a/test/unit/lib/code-docs/sassdoc/nodes/base.test.js
+++ b/test/unit/lib/code-docs/sassdoc/nodes/base.test.js
@@ -46,9 +46,9 @@ describe('lib/code-docs/sassdoc/nodes/base', () => {
         },
         'brand': {
             'supported': [
-                'master'
+                'core'
             ],
-            'description': 'Only master brand supported in this example'
+            'description': 'Only core brand supported in this example'
         },
         'link': [
             {
@@ -116,8 +116,8 @@ describe('lib/code-docs/sassdoc/nodes/base', () => {
             name: 'helpers'
         }, 'Did not add expected group property.');
         assert.deepEqual(node.brand, {
-            description: 'Only master brand supported in this example',
-            supported: ['master']
+            description: 'Only core brand supported in this example',
+            supported: ['core']
         }, 'Did not add expected brand property.');
         assert.equal(node.deprecated, 'This function has been replaced. Please contact Origami with any questions.', 'Did not add expected deprecated property.');
         assert.deepEqual(node.links, [

--- a/views/partials/component/messages.html
+++ b/views/partials/component/messages.html
@@ -86,7 +86,7 @@
 					{{#ifEquals versions.0.version component.version}}
 						<p class="o-message__content-main">
 							<span class="o-message__content-highlight">
-								{{component.name}} hasn't been branded yet, it only supports the master brand.
+								{{component.name}} hasn't been branded yet, it only supports the core brand.
 							</span>
 							<span class="o-message__content-detail">
 								If you would like to discuss having it branded <a class="o-message__actions__secondary o-layout__unstyled-element" href="#support"> please get in touch with the Origami team</a>.

--- a/views/partials/component/quickstart-sidebar.html
+++ b/views/partials/component/quickstart-sidebar.html
@@ -48,7 +48,7 @@
 					{{#component.brands}}
 						<option
 							value="{{this}}"
-							data-redirect="/components/{{@root.component.name}}@{{@root.component.version}}/{{#ifAny @root.nav 'sassdoc' 'jsdoc' 'readme'}}{{@root.nav}}/{{/ifAny}}{{#unlessEquals this 'master' }}?brand={{this}}{{/unlessEquals}}"
+							data-redirect="/components/{{@root.component.name}}@{{@root.component.version}}/{{#ifAny @root.nav 'sassdoc' 'jsdoc' 'readme'}}{{@root.nav}}/{{/ifAny}}{{#unlessEquals this 'core' }}?brand={{this}}{{/unlessEquals}}"
 							{{#ifEquals this @root.currentBrand}}selected="true"{{/ifEquals}}>
 							{{this}}
 						</option>
@@ -68,7 +68,7 @@
 					{{#versions}}
 						<option
 							value="{{version}}"
-							data-redirect="/components/{{@root.component.name}}@{{version}}/{{#ifAny @root.nav 'sassdoc' 'jsdoc' 'readme'}}{{@root.nav}}/{{/ifAny}}{{#unlessEquals @root.currentBrand 'master' }}?brand={{@root.currentBrand}}{{/unlessEquals}}"
+							data-redirect="/components/{{@root.component.name}}@{{version}}/{{#ifAny @root.nav 'sassdoc' 'jsdoc' 'readme'}}{{@root.nav}}/{{/ifAny}}{{#unlessEquals @root.currentBrand 'core' }}?brand={{@root.currentBrand}}{{/unlessEquals}}"
 							{{#ifEquals version @root.component.version}}data-test="current-version" selected="true"{{/ifEquals}}>
 							{{version}}
 						</option>
@@ -110,7 +110,7 @@
 		<details>
 			<summary id="use">Download images</summary>
 			<p>To add images to your project we recommend using the <a class="registry-link registry-link-external" href="https://www.ft.com/__origami/service/image/v2/">Image Service</a>. However you may download the full image set using the button below. It will download the Github repository, with all the image files in a sub folder.</p>
-			<a href="{{@root.component.url}}/archive/master.zip" class="download-button o-layout__unstyled-element o-buttons o-buttons--secondary o-buttons--mono">Download the Imageset</a>
+			<a href="{{@root.component.url}}/archive/core.zip" class="download-button o-layout__unstyled-element o-buttons o-buttons--secondary o-buttons--mono">Download the Imageset</a>
 		</details>
 
 		{{#if component.support.isOrigami}}
@@ -141,7 +141,7 @@
 					{{#if @root.component.hasCSS}}link tag.{{/if}}
 				{{/ifBoth}}
 				{{#if @root.component.hasCSS}}
-					{{#unlessEquals @root.currentBrand 'master'}}
+					{{#unlessEquals @root.currentBrand 'core'}}
 						Ensure the correct brand is set with a query parameter <code class="o-syntax-highlight--html">&brand={{@root.currentBrand}}</code>.
 					{{/unlessEquals}}
 				{{/if}}

--- a/views/partials/overview/component-list-item.html
+++ b/views/partials/overview/component-list-item.html
@@ -21,7 +21,7 @@
 				{{^brands}}
 					{{#languages}}
 						{{#ifEquals 'scss' . }}
-							<label title="Supported brand" class="o-labels o-labels--master">master</label>
+							<label title="Supported brand" class="o-labels o-labels--core">core</label>
 						{{/ifEquals}}
 					{{/languages}}
 				{{/brands}}


### PR DESCRIPTION
This is definitely not dry or well tested, but good enough
whilst this iteration of the registry lives.

https://github.com/Financial-Times/origami/issues/243