### PR TITLE
Itchy

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -136,6 +136,7 @@ module.exports = app => {
 
 			/// component.isComponent is confusing, "component" could be any Origami project type, for example a library "lib"
 			component.isComponent = component.type === 'component' || component.type === 'module';
+			component.showRequiredPolyfills = component.isComponent;
 
 			// Check for component languages
 			if (component.languages) {
@@ -299,6 +300,64 @@ module.exports = app => {
 		const currentBrand = request.currentBrand;
 
 		try {
+			// Render the details page
+			response.status(410);
+			response.render('details', {
+				title: `${component.name} - ${app.ft.options.name}`,
+				canonical: component.canonicalUrl,
+				component,
+				versions,
+				currentBrand,
+				nav: 'details',
+				heading: 'Details'
+			});
+
+		} catch (error) {
+			next(error);
+		}
+	});
+
+	// Individual component polyfill page
+	app.get('/components/:componentId/polyfills', cacheForFiveMinutes, findComponentId, switchBrandAndVersion, findComponent, findBrand, async (request, response, next) => {
+		const component = request.component;
+		const versions = request.versions;
+		const currentBrand = request.currentBrand;
+
+		if(!component.showRequiredPolyfills) {
+			return next(httpError(404));
+		}
+
+		try {
+			let browserFeatures;
+			const origamiManifest = await app.repoData.getManifest(component.repo, component.id, 'origami');
+			if (origamiManifest && origamiManifest.browserFeatures) {
+				browserFeatures = origamiManifest.browserFeatures;
+			}
+
+			// Render the details page
+			response.render('polyfills', {
+				title: `${component.name} - ${app.ft.options.name}`,
+				canonical: component.canonicalUrl,
+				component,
+				versions,
+				currentBrand,
+				browserFeatures,
+				nav: 'polyfills',
+				heading: 'Polyfills'
+			});
+
+		} catch (error) {
+			next(error);
+		}
+	});
+
+	// Individual component dependency page
+	app.get('/components/:componentId/dependencies', cacheForFiveMinutes, findComponentId, switchBrandAndVersion, findComponent, findBrand, async (request, response, next) => {
+		const component = request.component;
+		const versions = request.versions;
+		const currentBrand = request.currentBrand;
+
+		try {
 			// Load dependencies
 			let dependencies;
 			if (component.resources.dependencies) {
@@ -313,23 +372,16 @@ module.exports = app => {
 				};
 			}
 
-			let browserFeatures;
-			const origamiManifest = await app.repoData.getManifest(component.repo, component.id, 'origami');
-			if (origamiManifest && origamiManifest.browserFeatures) {
-				browserFeatures = origamiManifest.browserFeatures;
-			}
-
 			// Render the details page
-			response.render('details', {
+			response.render('dependencies', {
 				title: `${component.name} - ${app.ft.options.name}`,
 				canonical: component.canonicalUrl,
 				component,
 				dependencies,
 				versions,
 				currentBrand,
-				browserFeatures,
-				nav: 'details',
-				heading: 'Details'
+				nav: 'dependencies',
+				heading: 'Dependencies'
 			});
 
 		} catch (error) {

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -351,44 +351,6 @@ module.exports = app => {
 		}
 	});
 
-	// Individual component dependency page
-	app.get('/components/:componentId/dependencies', cacheForFiveMinutes, findComponentId, switchBrandAndVersion, findComponent, findBrand, async (request, response, next) => {
-		const component = request.component;
-		const versions = request.versions;
-		const currentBrand = request.currentBrand;
-
-		try {
-			// Load dependencies
-			let dependencies;
-			if (component.resources.dependencies) {
-				const forBower = (dependency) => dependency.source === 'bower' && !dependency.isDev;
-				const forNPM = (dependency) => dependency.source === 'npm' && !dependency.isDev;
-
-				const dependencyList = await app.repoData.listDependencies(component.repo, component.id);
-
-				dependencies = {
-					bower: dependencyList.filter(forBower),
-					npm: dependencyList.filter(forNPM)
-				};
-			}
-
-			// Render the details page
-			response.render('dependencies', {
-				title: `${component.name} - ${app.ft.options.name}`,
-				canonical: component.canonicalUrl,
-				component,
-				dependencies,
-				versions,
-				currentBrand,
-				nav: 'dependencies',
-				heading: 'Dependencies'
-			});
-
-		} catch (error) {
-			next(error);
-		}
-	});
-
 	// Individual component JsDoc page
 	app.get('/components/:componentId/jsdoc', cacheForFiveMinutes, findComponentId, switchBrandAndVersion, findComponent, findBrand, async (request, response, next) => {
 		const component = request.component;

--- a/src/main.js
+++ b/src/main.js
@@ -11,16 +11,18 @@ import '@financial-times/o-autoinit';
 import oTracking from '@financial-times/o-tracking';
 import CookieMessage from '@financial-times/o-cookie-message';
 
-const cookieMessage = new CookieMessage();
 
-const hasConsentedToCookies = cookieMessage.shouldShowCookieMessage() === false;
-if (hasConsentedToCookies) {
-	turnOnTracking();
-} else {
-	document.body.addEventListener('oCookieMessage.act', () => {
+document.addEventListener('o.DOMContentLoaded', () => {
+	const cookieMessage = new CookieMessage();
+	const hasConsentedToCookies = cookieMessage.shouldShowCookieMessage() === false;
+	if (hasConsentedToCookies) {
 		turnOnTracking();
-	});
-}
+	} else {
+		document.body.addEventListener('oCookieMessage.act', () => {
+			turnOnTracking();
+		});
+	}
+});
 
 function turnOnTracking() {
 	oTracking.init({

--- a/test/integration/routes/components-(id)-polyfills.test.js
+++ b/test/integration/routes/components-(id)-polyfills.test.js
@@ -3,17 +3,17 @@
 
 const assert = require('proclaim');
 
-describe('GET /components/:componentId/details', () => {
+describe('GET /components/:componentId/polyfills', () => {
     let request;
 
     describe('when a component name and version is provided', () => {
 
         beforeEach(async () => {
-            request = agent.get('/components/o-example-active@2.0.0/details');
+            request = agent.get('/components/o-example-active@2.0.0/polyfills');
         });
 
-        it('responds with a 410 status', () => {
-            return request.expect(410);
+        it('responds with a 200 status', () => {
+            return request.expect(200);
         });
 
         it('responds with HTML', () => {
@@ -28,10 +28,12 @@ describe('GET /components/:componentId/details', () => {
                 text = (await request.then()).text;
             });
 
-            it('directs the reader to the newer polyfills page or Github for a list of dependencies', () => {
-                assert.include(text, 'replaced');
-                assert.include(text, 'Github');
-                assert.include(text, 'polyfills');
+            it('includes the component\'s required browser features', () => {
+                assert.include(text, 'DOMTokenList');
+            });
+
+            it('includes the component\'s optional browser features', () => {
+                assert.include(text, 'IntersectionObserver');
             });
         });
 
@@ -40,7 +42,7 @@ describe('GET /components/:componentId/details', () => {
     describe('when only a component name is provided', () => {
 
         beforeEach(async () => {
-            request = agent.get('/components/o-example-active/details');
+            request = agent.get('/components/o-example-active/polyfills');
         });
 
         it('responds with a 307 status', () => {
@@ -48,7 +50,7 @@ describe('GET /components/:componentId/details', () => {
         });
 
         it('responds with a Location header pointing to the latest version page', () => {
-            return request.expect('Location', '/components/o-example-active@2.0.0/details');
+            return request.expect('Location', '/components/o-example-active@2.0.0/polyfills');
         });
 
     });
@@ -56,7 +58,7 @@ describe('GET /components/:componentId/details', () => {
     describe('when a component name and a "latest" version identifier is provided', () => {
 
         beforeEach(async () => {
-            request = agent.get('/components/o-example-active@latest/details');
+            request = agent.get('/components/o-example-active@latest/polyfills');
         });
 
         it('responds with a 307 status', () => {
@@ -64,7 +66,7 @@ describe('GET /components/:componentId/details', () => {
         });
 
         it('responds with a Location header pointing to the latest version page', () => {
-            return request.expect('Location', '/components/o-example-active@2.0.0/details');
+            return request.expect('Location', '/components/o-example-active@2.0.0/polyfills');
         });
 
     });
@@ -72,7 +74,7 @@ describe('GET /components/:componentId/details', () => {
     describe('when the named component does not exist', () => {
 
         beforeEach(async () => {
-            request = agent.get('/components/o-not-a-component/details');
+            request = agent.get('/components/o-not-a-component/polyfills');
         });
 
         it('responds with a 404 status', () => {
@@ -88,7 +90,7 @@ describe('GET /components/:componentId/details', () => {
     describe('when the named component version does not exist', () => {
 
         beforeEach(async () => {
-            request = agent.get('/components/o-example-active@123.456.789/details');
+            request = agent.get('/components/o-example-active@123.456.789/polyfills');
         });
 
         it('responds with a 404 status', () => {

--- a/views/details.html
+++ b/views/details.html
@@ -1,126 +1,65 @@
 <div class="o-layout o-layout--query" data-o-component="o-layout">
-	<div class="o-layout__header">
-		 {{> header }}
-	</div>
-
-	<div class="o-layout__heading">
-		<div class="o-layout-typography">
-			{{> component/header}}
-		</div>
-        {{> component/messages}}
-	</div>
-
-	<div class="o-layout__query-sidebar">
-    {{#ifEither dependencies.bower.length dependencies.npm.length}}
-        <nav class="o-layout__navigation">
-            <ol>
-                {{#if browserFeatures.required.length}}
-                    <li><a href="#required-browser-features">Required Browser Features</a></li>
-                {{/if}}
-                {{#if browserFeatures.optional.length}}
-                    <li><a href="#optional-browser-features">Optional Browser Features</a></li>
-                {{/if}}
-                {{#if dependencies.bower.length}}
-                    <li><a href="#bower">Bower Dependencies</a></li>
-                {{/if}}
-                {{#if dependencies.npm.length}}
-                    <li><a href="#npm">NPM Dependencies</a></li>
-                {{/if}}
-            </ol>
-        </nav>
-    {{/ifEither}}
-	</div>
-
-    <div class="o-layout__main o-layout-typography" data-o-component="o-syntax-highlight">
-
-        {{#ifEither browserFeatures.required.length browserFeatures.optional.length}}
-            {{#if browserFeatures.required.length}}
-                <h2 id="required-browser-features">Required Browser Features</h2>
-                <p>{{ component.name }}@^{{ component.version }} requires the following browser features:</p>
-                <ul>
-                {{#each browserFeatures.required}}
-                    <li>
-                        <code>{{ . }}</code>
-                    </li>
-                {{/each}}
-                </ul>
-
-            {{/if}}
-            {{#if browserFeatures.optional.length}}
-                <h2 id="optional-browser-features">Optional Browser Features</h2>
-                <p>{{ component.name }}@^{{ component.version }} works best for browsers which support the following features, but will handle cases where they are not avalible:</p>
-                <ul>
-                {{#each browserFeatures.optional}}
-                    <li>
-                        <code>{{ . }}</code>
-                    </li>
-                {{/each}}
-                </ul>
-            {{/if}}
-            <p>We recommend <a href="https://polyfill.io/v3/">polyfill.io</a> to add support for missing features to older browsers.</p>
-        {{/ifEither}}
-
-        {{#ifEither dependencies.bower.length dependencies.npm.length}}
-            {{#if dependencies.npm.length}}
-                <h2 id="npm">NPM Dependencies</h2>
-                <div class="o-table-container">
-                    <div class="o-table-overlay-wrapper">
-                        <div class="o-table-scroll-wrapper">
-                            <table class="o-table o-table--horizontal-lines  o-table--responsive-overflow" data-o-component="o-table" data-o-table-sortable="false" data-o-table-responsive="overflow">
-                                <thead>
-                                    <tr>
-                                        <th scope="col" role="columnheader">Dependency</th>
-                                        <th scope="col" role="columnheader" data-o-table-data-type="numeric">Version</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                {{#each dependencies.npm}}
-                                    <tr>
-                                        <td>{{name}}</td>
-                                        <td>{{version}}</td>
-                                    </tr>
-                                {{/each}}
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-            {{/if}}
-            {{#if dependencies.bower.length}}
-                <h2 id="bower">Bower Dependencies</h2>
-                <div class="o-table-container">
-                    <div class="o-table-overlay-wrapper">
-                        <div class="o-table-scroll-wrapper">
-                            <table class="o-table o-table--horizontal-lines  o-table--responsive-overflow" data-o-component="o-table" data-o-table-sortable="false" data-o-table-responsive="overflow">
-                                <thead>
-                                    <tr>
-                                        <th scope="col" role="columnheader">Dependency</th>
-                                        <th scope="col" role="columnheader" data-o-table-data-type="numeric">Version</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                {{#each dependencies.bower}}
-                                    <tr>
-                                        <td>{{name}}</td>
-                                        <td>{{version}}</td>
-                                    </tr>
-                                {{/each}}
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-            {{/if}}
-        {{ else }}
-            {{ component.name }} has no dependencies.
-        {{/ifEither}}
+    <div class="o-layout__header">
+        {{> header }}
     </div>
 
-	<div class="o-layout__aside-sidebar o-layout-typography" data-o-component="o-syntax-highlight">
-		{{> component/quickstart-sidebar}}
-	</div>
+    <div class="o-layout__heading">
+        <div class="o-layout-typography">
+            {{> component/header}}
+        </div>
+        {{> component/messages}}
+    </div>
 
-	<div class="o-layout__footer">
-		{{> footer}}
-	</div>
+    <div class="o-layout__query-sidebar">
+    </div>
+
+    <div class="o-layout__main" data-o-component="o-syntax-highlight">
+
+        <div class="o-message o-message--notice  o-message--inform" data-o-component="o-message" data-close="false">
+            <div class="o-message__container">
+                <div class="o-message__content">
+                    {{#@root.component.showRequiredPolyfills}}
+                        <p class="o-message__content-main">
+                            <span class="o-message__content-highlight">The component details page has been replaced.</span>
+                            <span>
+                                browser features which require a polyfill for {{ component.name }} support are now listed under the "Required polyfills" page. Component dependencies are no longer listed under the registry, these can be found on Github.
+                            </span>
+                        </p>
+                        <div class="o-message__actions">
+                            <a href="./polyfills/?brand={{supportedBrand}}" class="o-message__actions__primary">{{ component.name }} required polyfills</a>
+                            {{#ifEquals @root.component.origamiVersion '1'}}
+                            <a href="https://github.com/Financial-Times/{{ @root.component.name }}/tree/v{{ @root.component.version }}/{{#if file}}{{ file.path }}/{{ file.name }}#L{{ file.lineno }}{{/if}}" class="o-message__actions__secondary">{{ component.name }} on Github</a>
+                            {{else}}
+                            <a href="https://github.com/Financial-Times/origami/tree/{{ @root.component.name }}-v{{ @root.component.version }}/components/{{ @root.component.name }}" class="o-message__actions__secondary">{{ component.name }} on Github</a>
+                            {{/ifEquals}}
+                        </div>
+                    {{else}}
+                        <p class="o-message__content-main">
+                            <span class="o-message__content-highlight">The component details page has been replaced.</span>
+                            <span>
+                                Component dependencies are no longer listed under the registry, these can be found on Github.
+                            </span>
+                        </p>
+                        <div class="o-message__actions">
+                            {{#ifEquals @root.component.origamiVersion '1'}}
+                            <a href="https://github.com/Financial-Times/{{ @root.component.name }}/tree/v{{ @root.component.version }}/{{#if file}}{{ file.path }}/{{ file.name }}#L{{ file.lineno }}{{/if}}" class="o-message__actions__primary">{{ component.name }} on Github</a>
+                            {{else}}
+                            <a href="https://github.com/Financial-Times/origami/tree/{{ @root.component.name }}-v{{ @root.component.version }}/components/{{ @root.component.name }}" class="o-message__actions__primary">{{ component.name }} on Github</a>
+                            {{/ifEquals}}
+                        </div>
+                    {{/@root.component.showRequiredPolyfills}}
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+
+    <div class="o-layout__aside-sidebar o-layout-typography" data-o-component="o-syntax-highlight">
+        {{> component/quickstart-sidebar}}
+    </div>
+
+    <div class="o-layout__footer">
+        {{> footer}}
+    </div>
 </div>

--- a/views/partials/codedocs/nodes/sections/github-link.html
+++ b/views/partials/codedocs/nodes/sections/github-link.html
@@ -1,3 +1,9 @@
+{{#ifEquals @root.component.origamiVersion '1'}}
 <a class="link-external" href="https://github.com/Financial-Times/{{ @root.component.name }}/tree/v{{ @root.component.version }}/{{#if file}}{{ file.path }}/{{ file.name }}#L{{ file.lineno }}{{/if}}">
     "{{ name }}" {{ kind }} on Github
 </a>
+{{else}}
+<a class="link-external" href="https://github.com/Financial-Times/origami/tree/{{ @root.component.name }}-v{{ @root.component.version }}/components/{{ @root.component.name }}/{{#if file}}{{ file.path }}/{{ file.name }}#L{{ file.lineno }}{{/if}}">
+    "{{ name }}" {{ kind }} on Github
+</a>
+{{/ifEquals}}

--- a/views/partials/component/quickstart-sidebar.html
+++ b/views/partials/component/quickstart-sidebar.html
@@ -81,9 +81,15 @@
 		</fieldset>
 	</form>
 
-	<p>
-		<a class="registry-link registry-link--github" href="{{component.url}}">GitHub Repository</a>
-	</p>
+	{{#ifEquals @root.component.origamiVersion '1'}}
+		<p>
+			<a class="registry-link registry-link--github" href="{{@root.component.url}}">GitHub: {{ @root.component.name }}</a>
+		</p>
+	{{else}}
+		<p>
+			<a class="registry-link registry-link--github" href="https://github.com/Financial-Times/origami/tree/{{ @root.component.name }}-v{{ @root.component.version }}/components/{{ @root.component.name }}">GitHub: {{ @root.component.name }}@{{ @root.component.version }}</a>
+		</p>
+	{{/ifEquals}}
 
 	{{#ifEquals component.type 'service'}}
 		<details>

--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -67,11 +67,13 @@
 						</a>
 					</li>
 				{{/if}}
+				{{#if component.showRequiredPolyfills}}
 				<li>
-					<a href="/components/{{ component.name }}@{{ component.version }}/details{{#if @root.currentBrand}}?brand={{@root.currentBrand}}{{/if}}" {{#ifEquals nav 'details'}}aria-current="true"{{/ifEquals}}>
-						Details
+					<a href="/components/{{ component.name }}@{{ component.version }}/polyfills{{#if @root.currentBrand}}?brand={{@root.currentBrand}}{{/if}}" {{#ifEquals nav 'polyfills'}}aria-current="true"{{/ifEquals}}>
+						Required Polyfills
 					</a>
 				</li>
+				{{/if}}
 			</ul>
 		</div>
 		<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>

--- a/views/polyfills.html
+++ b/views/polyfills.html
@@ -1,0 +1,67 @@
+<div class="o-layout o-layout--query" data-o-component="o-layout">
+	<div class="o-layout__header">
+		 {{> header }}
+	</div>
+
+	<div class="o-layout__heading">
+		<div class="o-layout-typography">
+			{{> component/header}}
+		</div>
+        {{> component/messages}}
+	</div>
+
+	<div class="o-layout__query-sidebar">
+    {{#ifEither browserFeatures.required.length browserFeatures.optional.length}}
+        <nav class="o-layout__navigation">
+            <ol>
+                {{#if browserFeatures.required.length}}
+                    <li><a href="#required-browser-features">Required Browser Features</a></li>
+                {{/if}}
+                {{#if browserFeatures.optional.length}}
+                    <li><a href="#optional-browser-features">Optional Browser Features</a></li>
+                {{/if}}
+            </ol>
+        </nav>
+    {{/ifEither}}
+	</div>
+
+    <div class="o-layout__main o-layout-typography" data-o-component="o-syntax-highlight">
+
+        {{#ifEither browserFeatures.required.length browserFeatures.optional.length}}
+            {{#if browserFeatures.required.length}}
+                <h2 id="required-browser-features">Required Browser Features</h2>
+                <p>{{ component.name }}@^{{ component.version }} requires the following browser features:</p>
+                <ul>
+                {{#each browserFeatures.required}}
+                    <li>
+                        <code>{{ . }}</code>
+                    </li>
+                {{/each}}
+                </ul>
+
+            {{/if}}
+            {{#if browserFeatures.optional.length}}
+                <h2 id="optional-browser-features">Optional Browser Features</h2>
+                <p>{{ component.name }}@^{{ component.version }} works best for browsers which support the following features, but will handle cases where they are not avalible:</p>
+                <ul>
+                {{#each browserFeatures.optional}}
+                    <li>
+                        <code>{{ . }}</code>
+                    </li>
+                {{/each}}
+                </ul>
+            {{/if}}
+            <p>We recommend <a href="https://polyfill.io/v3/">polyfill.io</a> to add support for missing features to older browsers.</p>
+        {{else}}
+                <p>{{ component.name }}@^{{ component.version }} should not require any <a href="https://origami.ft.com/docs/components/compatibility/#polyfill-service">JavaScript polyfills</a> to support <a href="https://docs.google.com/document/d/1z6kecy_o9qHYIznTmqQ-IJqre72jhfd0nVa4JMsS7Q4/edit">browsers which the FT support</a>.</p>
+        {{/ifEither}}
+    </div>
+
+	<div class="o-layout__aside-sidebar o-layout-typography" data-o-component="o-syntax-highlight">
+		{{> component/quickstart-sidebar}}
+	</div>
+
+	<div class="o-layout__footer">
+		{{> footer}}
+	</div>
+</div>


### PR DESCRIPTION
A few nice fixes / improves for a Friday evening. 

- Fix Github links for mono repo versions of components/libraries. Closes: https://github.com/Financial-Times/origami-registry-ui/issues/617
- Replace details page with required polyfills page. Makes the polyfill list easier to find for now. Points to Github for a dependencies list instead to avoid lies.
- Fix tracking. Previously could run before `document.body` was available, causing an error.

See commit messages for more.

