### PR TITLE
fix: support library links to Github

### DIFF
--- a/views/partials/component/quickstart-sidebar.html
+++ b/views/partials/component/quickstart-sidebar.html
@@ -87,7 +87,11 @@
 		</p>
 	{{else}}
 		<p>
-			<a class="registry-link registry-link--github" href="https://github.com/Financial-Times/origami/tree/{{ @root.component.name }}-v{{ @root.component.version }}/components/{{ @root.component.name }}">GitHub: {{ @root.component.name }}@{{ @root.component.version }}</a>
+			{{#ifEquals @root.component.type 'library'}}
+				<a class="registry-link registry-link--github" href="https://github.com/Financial-Times/origami/tree/{{ @root.component.name }}-v{{ @root.component.version }}/libraries/{{ @root.component.name }}">GitHub: {{ @root.component.name }}@{{ @root.component.version }}</a>
+			{{else}}
+				<a class="registry-link registry-link--github" href="https://github.com/Financial-Times/origami/tree/{{ @root.component.name }}-v{{ @root.component.version }}/components/{{ @root.component.name }}">GitHub: {{ @root.component.name }}@{{ @root.component.version }}</a>
+			{{/ifEquals}}
 		</p>
 	{{/ifEquals}}
 


### PR DESCRIPTION
This is a bit quick and dirty. There are other types of Origami package. However these follow v1 of the Origami spec and so do not currently cause an issue.