### PR TITLE
404 for any Origami component the Registry does not support explicitly [OR-321]

### DIFF
--- a/lib/query-to-repo-filter.js
+++ b/lib/query-to-repo-filter.js
@@ -1,8 +1,11 @@
 'use strict';
+const supportedOrigamiVersions = require('./supported-origami-version');
 
 function queryToRepoFilter(query) {
 	const filter = {
-		status: [],
+		origamiVersion: supportedOrigamiVersions,
+		type: [],
+		status: []
 	};
 	if (!query) {
 		return filter;

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -13,6 +13,7 @@ const Sassdoc = require('../code-docs/sassdoc');
 const SassDocNav = require('../code-docs/sassdoc/nav');
 const { slugify } = require('../helpers');
 const semver = require('semver');
+const supportedOrigamiVersions = require('../supported-origami-version');
 
 module.exports = app => {
 
@@ -119,8 +120,8 @@ module.exports = app => {
 				component = versions.find(version => version.version === componentVersion);
 			}
 
-			// Check that we actually have a component
-			if (!component) {
+			// Check we have a component, that the registry knowns how to present.
+			if (!component || !supportedOrigamiVersions.includes(component.origamiVersion)) {
 				throw httpError(404);
 			}
 

--- a/lib/supported-origami-version.js
+++ b/lib/supported-origami-version.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = ["1", "2.0", "2.1"]; // 2.1 is a mistake in an existing component, n-notification

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@financial-times/o-tabs": "^6.0.0",
         "@financial-times/o-tracking": "^4.1.0",
         "@financial-times/o-typography": "^7.0.1",
-        "@financial-times/origami-repo-data-client": "1.6.3",
+        "@financial-times/origami-repo-data-client": "1.7.0",
         "@financial-times/origami-service": "6.0.0",
         "@financial-times/origami-service-makefile": "7.0.3",
         "cheerio": "1.0.0-rc.3",
@@ -1071,26 +1071,19 @@
       }
     },
     "node_modules/@financial-times/origami-repo-data-client": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/origami-repo-data-client/-/origami-repo-data-client-1.6.3.tgz",
-      "integrity": "sha512-GGiJ3eHjvk93+7NmqWotydmrui/2p+RYQw1NKEtZ9aspDVgdcgBqoN1e/R6tAVO7ke88qDPmLoPMoKfgUG93cw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/origami-repo-data-client/-/origami-repo-data-client-1.7.0.tgz",
+      "integrity": "sha512-Hjv7PmjUSBDvimN4ixrU7wjB0KTioASjMrVioTje4Z5JqOLZQThrXnmfFtDxcSYeW8hiFoxKuLUtpfM+wLNb+w==",
       "dependencies": {
-        "@financial-times/origami-service-makefile": "^6.1.0",
-        "lodash": "^4.17.5",
+        "@financial-times/origami-service-makefile": "^7.0.3",
+        "lodash": "^4.17.21",
         "request": "^2.87.0",
-        "request-promise-native": "^1.0.5"
+        "request-promise-native": "^1.0.5",
+        "snyk": "^1.611.0"
       },
       "engines": {
         "node": ">=8.6.0",
         "npm": ">=5"
-      }
-    },
-    "node_modules/@financial-times/origami-repo-data-client/node_modules/@financial-times/origami-service-makefile": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/origami-service-makefile/-/origami-service-makefile-6.4.0.tgz",
-      "integrity": "sha512-BAta9ElfKENOO+WTLNxmFu75uO+bImxXt20YWsHJTGEg4VzKTUMjXv77yDx5uc8mLJVuEiGNXJvNg2XMWxxT1Q==",
-      "dependencies": {
-        "esm": "^3.0.18"
       }
     },
     "node_modules/@financial-times/origami-service": {
@@ -3648,14 +3641,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/espree": {
@@ -10887,24 +10872,15 @@
       "requires": {}
     },
     "@financial-times/origami-repo-data-client": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/origami-repo-data-client/-/origami-repo-data-client-1.6.3.tgz",
-      "integrity": "sha512-GGiJ3eHjvk93+7NmqWotydmrui/2p+RYQw1NKEtZ9aspDVgdcgBqoN1e/R6tAVO7ke88qDPmLoPMoKfgUG93cw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/origami-repo-data-client/-/origami-repo-data-client-1.7.0.tgz",
+      "integrity": "sha512-Hjv7PmjUSBDvimN4ixrU7wjB0KTioASjMrVioTje4Z5JqOLZQThrXnmfFtDxcSYeW8hiFoxKuLUtpfM+wLNb+w==",
       "requires": {
-        "@financial-times/origami-service-makefile": "^6.1.0",
-        "lodash": "^4.17.5",
+        "@financial-times/origami-service-makefile": "^7.0.3",
+        "lodash": "^4.17.21",
         "request": "^2.87.0",
-        "request-promise-native": "^1.0.5"
-      },
-      "dependencies": {
-        "@financial-times/origami-service-makefile": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/@financial-times/origami-service-makefile/-/origami-service-makefile-6.4.0.tgz",
-          "integrity": "sha512-BAta9ElfKENOO+WTLNxmFu75uO+bImxXt20YWsHJTGEg4VzKTUMjXv77yDx5uc8mLJVuEiGNXJvNg2XMWxxT1Q==",
-          "requires": {
-            "esm": "^3.0.18"
-          }
-        }
+        "request-promise-native": "^1.0.5",
+        "snyk": "^1.611.0"
       }
     },
     "@financial-times/origami-service": {
@@ -12803,11 +12779,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "espree": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@financial-times/o-tabs": "^6.0.0",
     "@financial-times/o-tracking": "^4.1.0",
     "@financial-times/o-typography": "^7.0.1",
-    "@financial-times/origami-repo-data-client": "1.6.3",
+    "@financial-times/origami-repo-data-client": "1.7.0",
     "@financial-times/origami-service": "6.0.0",
     "@financial-times/origami-service-makefile": "7.0.3",
     "cheerio": "1.0.0-rc.3",

--- a/test/integration/mock/repo-data-api/data/repos.js
+++ b/test/integration/mock/repo-data-api/data/repos.js
@@ -8,7 +8,7 @@ module.exports = [
 		name: 'o-example-active',
 		type: 'module',
 		subType: 'primitives',
-		origamiVersion: 1,
+		origamiVersion: '1',
 		version: '2.0.0',
 		support: {
 			status: 'active',
@@ -102,7 +102,7 @@ module.exports = [
 		name: 'o-example-no-readme',
 		type: 'module',
 		subType: 'primitives',
-		origamiVersion: 1,
+		origamiVersion: '1',
 		version: '2.0.0',
 		support: {
 			status: 'active',
@@ -149,7 +149,7 @@ module.exports = [
 		name: 'o-example-maintained',
 		type: 'module',
 		subType: null,
-		origamiVersion: 1,
+		origamiVersion: '1',
 		version: '1.5.0',
 		support: {
 			status: 'maintained',
@@ -173,7 +173,7 @@ module.exports = [
 		name: 'o-example-service-maintained',
 		type: 'service',
 		subType: null,
-		origamiVersion: 1,
+		origamiVersion: '1',
 		version: '1.5.0',
 		support: {
 			status: 'maintained',
@@ -197,7 +197,7 @@ module.exports = [
 		name: 'o-example-deprecated',
 		type: null,
 		subType: null,
-		origamiVersion: 1,
+		origamiVersion: '1',
 		version: '1.0.0',
 		support: {
 			status: 'deprecated',
@@ -221,7 +221,7 @@ module.exports = [
 		name: 'n-example-active',
 		type: null,
 		subType: null,
-		origamiVersion: 1,
+		origamiVersion: '1',
 		version: '1.2.3',
 		support: {
 			status: 'active',
@@ -245,7 +245,7 @@ module.exports = [
 		name: 'o-example-demos-except-whitelabel',
 		type: null,
 		subType: null,
-		origamiVersion: 1,
+		origamiVersion: '1',
 		version: '1.5.0',
 		support: {
 			status: 'maintained',
@@ -272,6 +272,54 @@ module.exports = [
 
 		// mock use only
 		_versions: ['1.5.0', '1.4.0', '1.3.0', '1.2.0', '1.1.0', '1.0.0']
-	}
+	},
+
+	// v3 Origami component
+	{
+		name: 'o3-example-active',
+		type: 'module',
+		subType: null,
+		origamiVersion: '3.0',
+		version: '2.0.0',
+		support: {
+			status: 'active',
+			email: 'origami@example.com',
+			channel: {
+				name: '#example-channel',
+				url: 'mock-channel-url'
+			},
+			isOrigami: true
+		},
+		resources: {
+			demos: null,
+			dependencies: [
+				{
+					'name': 'example-dependency',
+					'version': '^1.2.3',
+					'source': 'bower',
+					'isDev': false,
+					'isOptional': false
+				}
+			]
+		},
+		manifests: {
+			'origami': {
+				'browserFeatures': {
+					'required': [
+						'DOMTokenList'
+					],
+					'optional': [
+						'IntersectionObserver'
+					]
+				}
+			}
+		},
+		markdown: {
+			readme: '# o-example-active\n## test-readme\nExample content.'
+		},
+
+		// mock use only
+		_versions: ['2.0.0', '1.1.1', '1.1.0', '1.0.1', '1.0.0']
+	},
 
 ];

--- a/test/integration/mock/repo-data-api/mock-service.js
+++ b/test/integration/mock/repo-data-api/mock-service.js
@@ -28,6 +28,10 @@ module.exports = async function mockRepoDataApi() {
 				repo.type === null && request.query.type === 'module'
 			);
 		}
+		// mimic origamiVersion search
+		if (request.query.origamiVersion) {
+			foundRepos = foundRepos.filter(repo => request.query.origamiVersion.includes(repo.origamiVersion));
+		}
 		response.send(foundRepos);
 	});
 

--- a/test/integration/routes/components-(id)-details.test.js
+++ b/test/integration/routes/components-(id)-details.test.js
@@ -101,4 +101,34 @@ describe('GET /components/:componentId/details', () => {
 
     });
 
+
+	describe('when the named component version exists as an "O3" component, which the registry does not support', () => {
+
+		beforeEach(async () => {
+			request = agent.get('/components/o3-example-active@2.0.0/details');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+		describe('HTML response', () => {
+			let html;
+
+			beforeEach(async () => {
+				html = (await request.then()).text;
+			});
+
+			it('contains the error details', () => {
+				assert.match(html, /not found/i);
+			});
+
+		});
+
+	});
+
 });

--- a/test/integration/routes/components-(id)-readme.test.js
+++ b/test/integration/routes/components-(id)-readme.test.js
@@ -144,4 +144,32 @@ describe('GET /components/:componentId/readme', () => {
 
     });
 
+    describe('when the named component version exists as an "O3" component, which the registry does not support', () => {
+
+		beforeEach(async () => {
+			request = agent.get('/components/o3-example-active@2.0.0/readme');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+		describe('HTML response', () => {
+			let html;
+
+			beforeEach(async () => {
+				html = (await request.then()).text;
+			});
+
+			it('contains the error details', () => {
+				assert.match(html, /not found/i);
+			});
+
+		});
+
+	});
 });

--- a/test/integration/routes/components-(id).test.js
+++ b/test/integration/routes/components-(id).test.js
@@ -339,4 +339,33 @@ describe('GET /components/:componentId', () => {
 
 	});
 
+	describe('when the named component version exists as an "O3" component, which the registry does not support', () => {
+
+		beforeEach(async () => {
+			request = agent.get('/components/o3-example-active@2.0.0');
+		});
+
+		it('responds with a 404 status', () => {
+			return request.expect(404);
+		});
+
+		it('responds with HTML', () => {
+			return request.expect('Content-Type', /text\/html/);
+		});
+
+		describe('HTML response', () => {
+			let html;
+
+			beforeEach(async () => {
+				html = (await request.then()).text;
+			});
+
+			it('contains the error details', () => {
+				assert.match(html, /not found/i);
+			});
+
+		});
+
+	});
+
 });

--- a/test/integration/routes/components.json.test.js
+++ b/test/integration/routes/components.json.test.js
@@ -18,7 +18,7 @@ describe('GET /components.json', () => {
 	 // Assertions here are based on data in `../mock/repo-data-api/data`
 	 describe('JSON response', () => {
 
-		  it('contains a list of all components', async () => {
+		  it('contains a list of all components with supported origamiVersion', async () => {
 				const request = agent.get('/components.json');
 				const json = (await request.then()).body;
 				assert.equal(json.length, 8, 'Expected 8 components.');

--- a/views/partials/component/quickstart-sidebar.html
+++ b/views/partials/component/quickstart-sidebar.html
@@ -127,7 +127,7 @@
 				{{/if}}
 			</p>
 
-			{{#ifEquals @root.component.origamiVersion 1}}
+			{{#ifEquals @root.component.origamiVersion "1"}}
 			<p>
 				If using the Bower package manager for a <a class="registry-link registry-link-external" href="{{ft.options.origamiSite}}documentation/tutorials/manual-build/">Manual Build</a>, run <code class="o-syntax-highlight--bash">bower install --save "{{@root.component.name}}@^{{@root.component.version}}"</code>.
 			</p>


### PR DESCRIPTION
We are very unlikely to present "O3" Origami components, components with an `origamiVersion` set to `3.0` in the registry. Instead we are using Storybook and intend to decommission the registry.

We also intend to decommission the Registry's source of data, origami-repo-data, which will not ingest "O3" components.

In theory then, this change is not required. It's a little defensive. However, if we change our minds on repo-data, or something goes wrong, then the Registry should not behave in an unexpected way.

Note that this also fixes a bug related to `origamiVersion`. Repo Data always returns a string but here we were assuming an integer. We relied on mocks for our tests, which made the same incorrect assumption.